### PR TITLE
Add Rust implementation of FlatFAT + Reactive Aggregator

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -49,3 +49,7 @@ pub mod soe;
 
 /// Two-Stacks
 pub mod two_stacks;
+
+/// Reactive-Aggregator
+pub mod reactive;
+

--- a/rust/src/reactive/flat_fat.rs
+++ b/rust/src/reactive/flat_fat.rs
@@ -1,0 +1,185 @@
+use alga::general::AbstractMonoid;
+use alga::general::Operator;
+use std::collections::HashSet;
+
+pub trait FAT<Value, BinOp>
+where
+    Value: AbstractMonoid<BinOp> + Clone,
+    BinOp: Operator,
+{
+    /// Creates a new FAT from a batch of values
+    fn new(batch: &[Value]) -> Self;
+
+    /// Creates a new FAT with uninitialized values
+    fn with_capacity(capacity: usize) -> Self;
+
+    /// Updates a non-contiguous batch of leaves
+    fn update<'a, I>(&mut self, batch: I)
+    where
+        I: IntoIterator<Item = &'a (usize, Value)>,
+        Value: 'a;
+
+    /// Updates a contiguous batch of leaves
+    fn update_ordered<'a, I>(&mut self, values: I)
+    where
+        I: IntoIterator<Item = &'a Value>,
+        Value: 'a;
+
+    /// Aggregates all nodes in the FAT and returns the result
+    fn aggregate(&self) -> Value;
+
+    /// Aggregates a prefix of nodes in the FAT and returns the result
+    fn prefix(&self, i: usize) -> Value;
+
+    /// Aggregates a suffix of nodes in the FAT and returns the result
+    fn suffix(&self, i: usize) -> Value;
+}
+
+pub struct FlatFAT<Value, BinOp>
+where
+    Value: AbstractMonoid<BinOp> + Clone,
+    BinOp: Operator,
+{
+    /// A flat binary tree, indexed as:
+    ///       0
+    ///      / \
+    ///     /   \
+    ///    1     2
+    ///   / \   / \
+    ///  3   4 5   6
+    pub(crate) tree: Vec<Value>,
+    /// Number of leaves which can be stored in the tree
+    pub(crate) capacity: usize,
+    binop: std::marker::PhantomData<BinOp>,
+}
+
+impl<Value, BinOp> FlatFAT<Value, BinOp>
+where
+    Value: AbstractMonoid<BinOp> + Clone,
+    BinOp: Operator,
+{
+    /// Returns all leaf nodes of the tree
+    pub(crate) fn leaves(&self) -> &[Value] {
+        &self.tree[self.leaf(0)..]
+    }
+    /// Returns the index of the root node
+    fn root(&self) -> usize {
+        0
+    }
+    /// Returns the index of a leaf node
+    fn leaf(&self, i: usize) -> usize {
+        i + self.capacity - 1
+    }
+    /// Returns the index of an node's left child
+    fn left(&self, i: usize) -> usize {
+        2 * (i + 1) - 1
+    }
+    /// Returns the index of an node's right child
+    fn right(&self, i: usize) -> usize {
+        2 * (i + 1)
+    }
+    /// Returns the index of an node's parent
+    fn parent(&self, i: usize) -> usize {
+        (i - 1) / 2
+    }
+}
+
+impl<Value, BinOp> FAT<Value, BinOp> for FlatFAT<Value, BinOp>
+where
+    Value: AbstractMonoid<BinOp> + Clone,
+    BinOp: Operator,
+{
+    fn new(values: &[Value]) -> Self {
+        let capacity = values.len();
+        let mut new = Self::with_capacity(capacity);
+        new.update_ordered(values);
+        new
+    }
+
+    fn with_capacity(capacity: usize) -> Self {
+        assert_ne!(capacity, 0, "Capacity of window must be greater than 0");
+        Self {
+            tree: vec![Value::identity(); 2 * capacity - 1],
+            binop: std::marker::PhantomData,
+            capacity,
+        }
+    }
+
+    fn update<'a, I>(&mut self, batch: I)
+    where
+        I: IntoIterator<Item = &'a (usize, Value)>,
+        Value: 'a,
+    {
+        let mut parents: HashSet<usize> = batch
+            .into_iter()
+            .map(|(idx, val)| {
+                let leaf = self.leaf(*idx);
+                self.tree[leaf] = val.clone();
+                self.parent(leaf)
+            })
+            .collect();
+        let mut new_parents: HashSet<usize> = HashSet::new();
+        loop {
+            parents.drain().for_each(|parent| {
+                let left = self.left(parent);
+                let right = self.right(parent);
+                self.tree[parent] = self.tree[left].operate(&self.tree[right]);
+                if parent != self.root() {
+                    new_parents.insert(self.parent(parent));
+                }
+            });
+            if new_parents.is_empty() {
+                break;
+            } else {
+                std::mem::swap(&mut parents, &mut new_parents);
+            }
+        }
+    }
+
+    fn update_ordered<'a, I>(&mut self, values: I)
+    where
+        I: IntoIterator<Item = &'a Value>,
+        Value: 'a,
+    {
+        values.into_iter().enumerate().for_each(|(idx, val)| {
+            let leaf = self.leaf(idx);
+            self.tree[leaf] = val.clone();
+        });
+        (0..self.leaf(0)).into_iter().rev().for_each(|parent| {
+            let left = self.left(parent);
+            let right = self.right(parent);
+            self.tree[parent] = self.tree[left].operate(&self.tree[right]);
+        });
+    }
+
+    fn aggregate(&self) -> Value {
+        self.tree[self.root()].clone()
+    }
+
+    fn prefix(&self, idx: usize) -> Value {
+        let mut node = self.leaf(idx);
+        let mut agg = self.tree[node].clone();
+        while node != self.root() {
+            let parent = self.parent(node);
+            if node == self.right(parent) {
+                let left = self.left(parent);
+                agg = self.tree[left].operate(&agg);
+            }
+            node = parent;
+        }
+        return agg;
+    }
+
+    fn suffix(&self, i: usize) -> Value {
+        let mut node = self.leaf(i);
+        let mut agg = self.tree[node].clone();
+        while node != self.root() {
+            let parent = self.parent(node);
+            if node == self.left(parent) {
+                agg = agg.operate(&self.tree[self.right(parent)]);
+            }
+            node = parent;
+        }
+        return agg;
+    }
+}

--- a/rust/src/reactive/mod.rs
+++ b/rust/src/reactive/mod.rs
@@ -40,10 +40,11 @@ where
             fat.update_ordered(
                 leaves[self.front..]
                     .iter()
-                    .chain(leaves[..self.back].iter()),
+                    .chain(leaves[..self.back].iter())
+                    .cloned(),
             );
         } else {
-            fat.update_ordered(leaves[self.front..self.back].iter());
+            fat.update_ordered(leaves[self.front..self.back].iter().cloned());
         }
         self.fat = fat;
         self.front = 0;
@@ -65,7 +66,7 @@ where
         }
     }
     fn push(&mut self, v: Value) {
-        self.fat.update(&[(self.back, v)]);
+        self.fat.update([(self.back, v)].iter().cloned());
         self.size += 1;
         self.back += 1;
         if self.size > (3 * self.fat.capacity) / 4 {
@@ -73,7 +74,8 @@ where
         }
     }
     fn pop(&mut self) {
-        self.fat.update(&[(self.front, Value::identity())]);
+        self.fat
+            .update([(self.front, Value::identity())].iter().cloned());
         self.size -= 1;
         self.front += 1;
         if self.size <= self.fat.capacity / 4 {

--- a/rust/src/reactive/mod.rs
+++ b/rust/src/reactive/mod.rs
@@ -1,0 +1,92 @@
+pub(crate) mod flat_fat;
+
+use crate::reactive::flat_fat::{FlatFAT, FAT};
+use crate::FifoWindow;
+use alga::general::AbstractMonoid;
+use alga::general::Operator;
+
+pub struct Reactive<Value, BinOp>
+where
+    Value: AbstractMonoid<BinOp> + Clone,
+    BinOp: Operator,
+{
+    fat: FlatFAT<Value, BinOp>,
+    size: usize,
+    front: usize,
+    back: usize,
+}
+
+impl<Value, BinOp> Reactive<Value, BinOp>
+where
+    Value: AbstractMonoid<BinOp> + Clone,
+    BinOp: Operator,
+{
+    /// Returns a Reactive Aggregator with a pre-allocated `capacity`
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            fat: FlatFAT::with_capacity(capacity),
+            size: 0,
+            front: 0,
+            back: 0,
+        }
+    }
+    fn inverted(&self) -> bool {
+        return self.front > self.back;
+    }
+    fn resize(&mut self, capacity: usize) {
+        let leaves = self.fat.leaves();
+        let mut fat = FlatFAT::with_capacity(capacity);
+        if self.inverted() {
+            fat.update_ordered(
+                leaves[self.front..]
+                    .iter()
+                    .chain(leaves[..self.back].iter()),
+            );
+        } else {
+            fat.update_ordered(leaves[self.front..self.back].iter());
+        }
+        self.fat = fat;
+        self.front = 0;
+        self.back = self.size;
+    }
+}
+
+impl<Value, BinOp> FifoWindow<Value, BinOp> for Reactive<Value, BinOp>
+where
+    Value: AbstractMonoid<BinOp> + Clone,
+    BinOp: Operator,
+{
+    fn new() -> Self {
+        Self {
+            fat: FlatFAT::with_capacity(8),
+            size: 0,
+            front: 0,
+            back: 0,
+        }
+    }
+    fn push(&mut self, v: Value) {
+        self.fat.update(&[(self.back, v)]);
+        self.size += 1;
+        self.back += 1;
+        if self.size > (3 * self.fat.capacity) / 4 {
+            self.resize(self.fat.capacity * 2);
+        }
+    }
+    fn pop(&mut self) {
+        self.fat.update(&[(self.front, Value::identity())]);
+        self.size -= 1;
+        self.front += 1;
+        if self.size <= self.fat.capacity / 4 {
+            self.resize(self.fat.capacity / 2);
+        }
+    }
+    fn query(&self) -> Value {
+        if self.front > self.back {
+            self.fat
+                .suffix(self.front)
+                .operate(&self.fat.prefix(self.back))
+        } else {
+            self.fat.aggregate()
+        }
+    }
+}

--- a/rust/tests/fifo-window.rs
+++ b/rust/tests/fifo-window.rs
@@ -8,6 +8,7 @@ use alga::general::Identity;
 use alga::general::Operator;
 use alga::general::TwoSidedInverse;
 use rand::Rng;
+use swag::reactive::*;
 use swag::recalc::*;
 use swag::soe::*;
 use swag::two_stacks::*;
@@ -121,4 +122,14 @@ fn test1_two_stacks() {
 #[test]
 fn test2_two_stacks() {
     test2::<TwoStacks<Value, Sum>>();
+}
+
+#[test]
+fn test1_reactive() {
+    test1::<Reactive<Value, Sum>>();
+}
+
+#[test]
+fn test2_reactive() {
+    test2::<Reactive<Value, Sum>>();
 }


### PR DESCRIPTION
Here is FlatFat and the (FIFO) Reactive Aggregator. Here are some notes:

* The FlatFAT implementation currently uses 0-indexing. It might be better to make it 1-indexed.
* There are two functions for updating the tree: `update` and `update_ordered`. The former updates specific leaves according to their position while the latter updates the entire tree in one-go. I am unsure about the naming, maybe there is a better way to distinguish them.
* The implementation uses `.for_each(|...| { ... });` instead of `for ... in ... { ... }` loops. The `for_each` loops are uglier but can from what I have heard sometimes give better performance when used with iterators like `.chain(...)`.
* Currently the implementation does not support out-of-order evicts.

Would you like me to fix something? If so please let me know! :)