### PR TITLE
Add a benchmark suite for Rust fifo-windows

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,6 +13,10 @@ license-file       = "../LICENSE"
 edition            = "2018"
 publish            = false
 
+[[bench]]
+name               = "bench_main"
+harness            = false
+
 [lib]
 name               = "swag"
 path               = "src/lib.rs"
@@ -26,7 +30,12 @@ fxhash             = "0.2.1"
 
 [dev-dependencies]
 criterion          = "0.3.3"
+criterion-cpu-time = "0.1.0"
+criterion-cycles-per-byte = "0.1.1"
+criterion-perf-events = "0.1.1"
 trybuild           = "1.0.30"
+
+# https://doc.rust-lang.org/cargo/reference/profiles.html
 
 [profile.dev]
 opt-level          = 0
@@ -58,6 +67,7 @@ codegen-units      = 1
 opt-level          = 3
 debug              = 0
 rpath              = false
-lto                = false
+lto                = true
 debug-assertions   = false
 codegen-units      = 1
+overflow-checks    = false

--- a/rust/benches/bench_main.rs
+++ b/rust/benches/bench_main.rs
@@ -1,0 +1,7 @@
+use criterion::criterion_main;
+
+mod benchmarks;
+
+criterion_main![
+    benchmarks::fifo_window::experiments
+];

--- a/rust/benches/benchmarks/fifo_window.rs
+++ b/rust/benches/benchmarks/fifo_window.rs
@@ -1,0 +1,81 @@
+#[path = "../../tests/common.rs"]
+mod common;
+use common::*;
+
+use alga::general::Operator;
+use criterion::*;
+use criterion_cpu_time::PosixTime;
+use swag::reactive::Reactive;
+use swag::recalc::ReCalc;
+use swag::soe::SoE;
+use swag::two_stacks::TwoStacks;
+use swag::FifoWindow;
+
+criterion_group! {
+    name = experiments;
+    config = Criterion::default()
+        .with_measurement(PosixTime::UserTime);
+    targets =
+      bench_sum,
+      bench_max
+}
+
+#[inline(always)]
+fn synthesize(size: u64) -> impl Iterator<Item = Int> {
+    (0..size as i64).map(Int)
+}
+
+fn run<BinOp, Window>(group: &mut BenchmarkGroup<PosixTime>, size_exp: u32, name: &str)
+where
+    Window: FifoWindow<Int, BinOp>,
+    BinOp: Operator,
+{
+    let initial_size = (2 as u64).pow(size_exp);
+    let initial_window = &mut Window::new();
+    let batch_size = (2 as u64).pow(12);
+    let group = group.throughput(Throughput::Elements(batch_size));
+    // Prefill the window
+    synthesize(initial_size).for_each(|item| initial_window.push(item));
+    assert_eq!(initial_window.len(), initial_size as usize);
+    // Begin the benchmark
+    group.bench_function(BenchmarkId::new(name, size_exp), move |bench| {
+        bench.iter_batched_ref(
+            // Clone window before starting each experiment (not included in measurement)
+            || initial_window.clone(),
+            // Code that is executed before every measurement
+            |window| {
+                synthesize(batch_size).for_each(|item| {
+                    Window::push(black_box(window), black_box(Int(item.0 % 101)));
+                    Window::pop(black_box(window));
+                    black_box(Window::query(black_box(window)));
+                })
+            },
+            // The input/output window can be kept in memory
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+pub fn bench_sum(criterion: &mut Criterion<PosixTime>) {
+    let group = &mut criterion.benchmark_group("Sum");
+    for size_exp in 0..=22 {
+        // ReCalc takes too long time for big inputs
+        if size_exp < 20 {
+            run::<Sum, ReCalc<_, _>>(group, size_exp, "ReCalc");
+        }
+        run::<Sum, Reactive<_, _>>(group, size_exp, "Reactive");
+        run::<Sum, SoE<_, _>>(group, size_exp, "SoE");
+        run::<Sum, TwoStacks<_, _>>(group, size_exp, "TwoStacks");
+    }
+}
+
+pub fn bench_max(criterion: &mut Criterion<PosixTime>) {
+    let group = &mut criterion.benchmark_group("Max");
+    for size_exp in 0..=22 {
+        if size_exp < 20 {
+            run::<Max, ReCalc<_, _>>(group, size_exp, "ReCalc");
+        }
+        run::<Max, Reactive<_, _>>(group, size_exp, "Reactive");
+        run::<Max, TwoStacks<_, _>>(group, size_exp, "TwoStacks");
+    }
+}

--- a/rust/benches/benchmarks/mod.rs
+++ b/rust/benches/benchmarks/mod.rs
@@ -1,0 +1,1 @@
+pub mod fifo_window;

--- a/rust/tests/fifo_window.rs
+++ b/rust/tests/fifo_window.rs
@@ -108,7 +108,6 @@ where
     for v in values {
         window.push(v);
         window.pop();
-        window.query();
         assert_eq!(window.query(), Int(sum));
     }
 }


### PR DESCRIPTION
This is a work in progress benchmark suite for Rust fifo-windows. There seems to be a bug in my Reactive implementation which makes it crash for large inputs 😢. The other implementations run and compile, but strangely ReCalc is beating TwoStacks. I will look into it and try understand why it's happening 🤔 

To execute the benchmark, it is enough to run:
```sh
$ cargo bench
```