### PR TITLE
Minor refactors, bugfix, features and test additions

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -22,6 +22,7 @@ num-traits         = "0.2.12"
 arrayvec           = "0.5.1"
 alga               = "0.9.3"
 rand               = "0.7.3"
+fxhash             = "0.2.1"
 
 [dev-dependencies]
 criterion          = "0.3.3"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -32,6 +32,8 @@ where
     fn query(&self) -> Value;
     /// Returns the number of elements inside the window.
     fn len(&self) -> usize;
+    /// Returns true if the window contains no elements.
+    fn is_empty(&self) -> bool;
 }
 
 /// An abstract data type which maintains sliding sub-window aggregates.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -30,6 +30,8 @@ where
     fn pop(&mut self);
     /// Combines the values in fifo order and returns the result, e.g., `1+v1+v2+...+vn`.
     fn query(&self) -> Value;
+    /// Returns the number of elements inside the window.
+    fn len(&self) -> usize;
 }
 
 /// An abstract data type which maintains sliding sub-window aggregates.

--- a/rust/src/reactive/flat_fat.rs
+++ b/rust/src/reactive/flat_fat.rs
@@ -103,7 +103,7 @@ where
     }
 
     fn with_capacity(capacity: usize) -> Self {
-        assert_ne!(capacity, 0, "Capacity of window must be greater than 0");
+        assert!(capacity > 1, "Capacity of window must be greater than 1");
         Self {
             tree: vec![Value::identity(); 2 * capacity - 1],
             binop: PhantomData,

--- a/rust/src/reactive/flat_fat.rs
+++ b/rust/src/reactive/flat_fat.rs
@@ -1,6 +1,7 @@
 use alga::general::AbstractMonoid;
 use alga::general::Operator;
 use std::collections::HashSet;
+use std::marker::PhantomData;
 
 pub(crate) trait FAT<Value, BinOp>: Clone
 where
@@ -49,7 +50,7 @@ where
     pub(crate) tree: Vec<Value>,
     /// Number of leaves which can be stored in the tree
     pub(crate) capacity: usize,
-    binop: std::marker::PhantomData<BinOp>,
+    binop: PhantomData<BinOp>,
 }
 
 impl<Value, BinOp> FlatFAT<Value, BinOp>
@@ -99,7 +100,7 @@ where
         assert_ne!(capacity, 0, "Capacity of window must be greater than 0");
         Self {
             tree: vec![Value::identity(); 2 * capacity - 1],
-            binop: std::marker::PhantomData,
+            binop: PhantomData,
             capacity,
         }
     }

--- a/rust/src/reactive/flat_fat.rs
+++ b/rust/src/reactive/flat_fat.rs
@@ -1,6 +1,6 @@
 use alga::general::AbstractMonoid;
 use alga::general::Operator;
-use std::collections::HashSet;
+use fxhash::FxHashSet as HashSet;
 use std::marker::PhantomData;
 
 pub(crate) trait FAT<Value, BinOp>: Clone
@@ -123,7 +123,7 @@ where
                 self.parent(leaf)
             })
             .collect();
-        let mut new_parents: HashSet<usize> = HashSet::new();
+        let mut new_parents: HashSet<usize> = HashSet::default();
         loop {
             parents.drain().for_each(|parent| {
                 let left = self.left(parent);

--- a/rust/src/reactive/flat_fat.rs
+++ b/rust/src/reactive/flat_fat.rs
@@ -59,26 +59,32 @@ where
     BinOp: Operator,
 {
     /// Returns all leaf nodes of the tree
+    #[inline(always)]
     pub(crate) fn leaves(&self) -> &[Value] {
         &self.tree[self.leaf(0)..]
     }
     /// Returns the index of the root node
+    #[inline(always)]
     fn root(&self) -> usize {
         0
     }
     /// Returns the index of a leaf node
+    #[inline(always)]
     fn leaf(&self, i: usize) -> usize {
         i + self.capacity - 1
     }
     /// Returns the index of an node's left child
+    #[inline(always)]
     fn left(&self, i: usize) -> usize {
         2 * i + 1
     }
     /// Returns the index of an node's right child
+    #[inline(always)]
     fn right(&self, i: usize) -> usize {
         2 * i + 2
     }
     /// Returns the index of an node's parent
+    #[inline(always)]
     fn parent(&self, i: usize) -> usize {
         (i - 1) / 2
     }

--- a/rust/src/reactive/flat_fat.rs
+++ b/rust/src/reactive/flat_fat.rs
@@ -72,11 +72,11 @@ where
     }
     /// Returns the index of an node's left child
     fn left(&self, i: usize) -> usize {
-        2 * (i + 1) - 1
+        2 * i + 1
     }
     /// Returns the index of an node's right child
     fn right(&self, i: usize) -> usize {
-        2 * (i + 1)
+        2 * i + 2
     }
     /// Returns the index of an node's parent
     fn parent(&self, i: usize) -> usize {

--- a/rust/src/reactive/mod.rs
+++ b/rust/src/reactive/mod.rs
@@ -60,7 +60,7 @@ where
 {
     fn new() -> Self {
         Self {
-            fat: FlatFAT::with_capacity(8),
+            fat: FlatFAT::with_capacity(2),
             size: 0,
             front: 0,
             back: 0,
@@ -75,12 +75,14 @@ where
         }
     }
     fn pop(&mut self) {
-        self.fat
-            .update([(self.front, Value::identity())].iter().cloned());
-        self.size -= 1;
-        self.front += 1;
-        if self.size <= self.fat.capacity / 4 {
-            self.resize(self.fat.capacity / 2);
+        if self.size > 0 {
+            self.fat
+                .update([(self.front, Value::identity())].iter().cloned());
+            self.size -= 1;
+            self.front += 1;
+            if self.size <= self.fat.capacity / 4 && self.size > 0 {
+                self.resize(self.fat.capacity / 2);
+            }
         }
     }
     fn query(&self) -> Value {

--- a/rust/src/reactive/mod.rs
+++ b/rust/src/reactive/mod.rs
@@ -32,7 +32,7 @@ where
         }
     }
     fn inverted(&self) -> bool {
-        self.front > self.back
+        self.front >= self.back
     }
     fn resize(&mut self, capacity: usize) {
         let leaves = self.fat.leaves();
@@ -69,7 +69,7 @@ where
     fn push(&mut self, v: Value) {
         self.fat.update([(self.back, v)].iter().cloned());
         self.size += 1;
-        self.back += 1;
+        self.back = (self.back + 1) % self.fat.capacity;
         if self.size > (3 * self.fat.capacity) / 4 {
             self.resize(self.fat.capacity * 2);
         }
@@ -79,7 +79,7 @@ where
             self.fat
                 .update([(self.front, Value::identity())].iter().cloned());
             self.size -= 1;
-            self.front += 1;
+            self.front = (self.front + 1) % self.fat.capacity;
             if self.size <= self.fat.capacity / 4 && self.size > 0 {
                 self.resize(self.fat.capacity / 2);
             }

--- a/rust/src/reactive/mod.rs
+++ b/rust/src/reactive/mod.rs
@@ -97,4 +97,7 @@ where
     fn len(&self) -> usize {
         self.size
     }
+    fn is_empty(&self) -> bool {
+        self.size == 0
+    }
 }

--- a/rust/src/reactive/mod.rs
+++ b/rust/src/reactive/mod.rs
@@ -94,4 +94,7 @@ where
             self.fat.aggregate()
         }
     }
+    fn len(&self) -> usize {
+        self.size
+    }
 }

--- a/rust/src/recalc/mod.rs
+++ b/rust/src/recalc/mod.rs
@@ -36,4 +36,7 @@ where
             .iter()
             .fold(Value::identity(), |acc, elem| acc.operate(&elem))
     }
+    fn len(&self) -> usize {
+        self.stack.len()
+    }
 }

--- a/rust/src/recalc/mod.rs
+++ b/rust/src/recalc/mod.rs
@@ -39,4 +39,7 @@ where
     fn len(&self) -> usize {
         self.stack.len()
     }
+    fn is_empty(&self) -> bool {
+        self.stack.is_empty()
+    }
 }

--- a/rust/src/soe/mod.rs
+++ b/rust/src/soe/mod.rs
@@ -39,4 +39,7 @@ where
     fn query(&self) -> Value {
         self.agg.clone()
     }
+    fn len(&self) -> usize {
+        self.stack.len()
+    }
 }

--- a/rust/src/soe/mod.rs
+++ b/rust/src/soe/mod.rs
@@ -42,4 +42,7 @@ where
     fn len(&self) -> usize {
         self.stack.len()
     }
+    fn is_empty(&self) -> bool {
+        self.stack.is_empty()
+    }
 }

--- a/rust/src/two_stacks/mod.rs
+++ b/rust/src/two_stacks/mod.rs
@@ -55,6 +55,9 @@ where
     fn query(&self) -> Value {
         Self::agg(&self.front).operate(&Self::agg(&self.back))
     }
+    fn len(&self) -> usize {
+        self.front.len() + self.back.len()
+    }
 }
 
 impl<Value, BinOp> TwoStacks<Value, BinOp>

--- a/rust/src/two_stacks/mod.rs
+++ b/rust/src/two_stacks/mod.rs
@@ -58,6 +58,9 @@ where
     fn len(&self) -> usize {
         self.front.len() + self.back.len()
     }
+    fn is_empty(&self) -> bool {
+        self.front.is_empty() && self.back.is_empty()
+    }
 }
 
 impl<Value, BinOp> TwoStacks<Value, BinOp>

--- a/rust/tests/common.rs
+++ b/rust/tests/common.rs
@@ -39,7 +39,7 @@ use alga::general::TwoSidedInverse;
 
 /// An integer value
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct Int(pub i32);
+pub struct Int(pub i64);
 
 /// Binary operator for calculating the arithmetic sum.
 /// Has the following properties:
@@ -94,7 +94,7 @@ impl Operator for Max {
 
 impl Identity<Max> for Int {
     fn identity() -> Int {
-        Int(std::i32::MIN)
+        Int(std::i64::MIN)
     }
 }
 

--- a/rust/tests/fifo_window.rs
+++ b/rust/tests/fifo_window.rs
@@ -78,6 +78,24 @@ where
     assert_eq!(window.query(), Int(std::i64::MIN));
 }
 
+/// Fills a window with 1M elements and pushes/pops/queries 1M times.
+fn test4<Window>()
+where
+    Window: FifoWindow<Int, Sum>,
+{
+    let mut window = Window::new();
+    let values = synthesize((2 as u64).pow(22) as usize);
+    let sum = values.iter().fold(0, |acc, Int(x)| acc + x);
+    for v in values.clone() {
+        window.push(v);
+    }
+    for v in values {
+        window.push(v);
+        window.pop();
+        assert_eq!(window.query(), Int(sum));
+    }
+}
+
 #[test]
 fn test1_recalc() {
     test1::<ReCalc<Int, Sum>>();
@@ -94,6 +112,11 @@ fn test3_recalc() {
 }
 
 #[test]
+fn test4_recalc() {
+    test4::<ReCalc<Int, Sum>>();
+}
+
+#[test]
 fn test1_soe() {
     test1::<SoE<Int, Sum>>();
 }
@@ -101,6 +124,11 @@ fn test1_soe() {
 #[test]
 fn test2_soe() {
     test2::<SoE<Int, Sum>>();
+}
+
+#[test]
+fn test4_soe() {
+    test4::<SoE<Int, Sum>>();
 }
 
 #[test]
@@ -119,6 +147,11 @@ fn test3_two_stacks() {
 }
 
 #[test]
+fn test4_two_stacks() {
+    test4::<TwoStacks<Int, Sum>>();
+}
+
+#[test]
 fn test1_reactive() {
     test1::<Reactive<Int, Sum>>();
 }
@@ -131,4 +164,9 @@ fn test2_reactive() {
 #[test]
 fn test3_reactive() {
     test3::<Reactive<Int, Max>>();
+}
+
+#[test]
+fn test4_reactive() {
+    test4::<Reactive<Int, Sum>>();
 }

--- a/rust/tests/fifo_window.rs
+++ b/rust/tests/fifo_window.rs
@@ -34,20 +34,20 @@ where
     assert_eq!(window.query(), Int(5));
 }
 
-fn generate() -> Vec<Int> {
+fn synthesize(size: usize) -> Vec<Int> {
     let mut rng = rand::thread_rng();
-    (0..1000)
+    (0..size)
         .map(|_| rng.gen_range(1, 5))
         .map(Int)
         .collect::<Vec<_>>()
 }
 
-/// Tries to aggregate the sum of 1000 randomly generated integers.
+/// Tries to aggregate the sum of 1M randomly generated integers.
 fn test2<Window>()
 where
     Window: FifoWindow<Int, Sum>,
 {
-    let values = generate();
+    let values = synthesize(1_000_000);
     let sum = values.iter().fold(0, |acc, Int(x)| acc + x);
     let mut window = Window::new();
     for v in values.clone() {
@@ -60,13 +60,13 @@ where
     assert_eq!(window.query(), Int(0));
 }
 
-/// Tries to find the maximum value out 1000 randomly generated integers.
+/// Tries to find the maximum value out 1M randomly generated integers.
 fn test3<Window>()
 where
     Window: FifoWindow<Int, Max>,
 {
     let mut window = Window::new();
-    let values = generate();
+    let values = synthesize(1_000_000);
     let max = values.iter().map(|Int(x)| *x).max().unwrap();
     for v in values.clone() {
         window.push(v);

--- a/rust/tests/fifo_window.rs
+++ b/rust/tests/fifo_window.rs
@@ -42,12 +42,12 @@ fn synthesize(size: usize) -> Vec<Int> {
         .collect::<Vec<_>>()
 }
 
-/// Tries to aggregate the sum of 1M randomly generated integers.
+/// Tries to aggregate the sum of 1K randomly generated integers.
 fn test2<Window>()
 where
     Window: FifoWindow<Int, Sum>,
 {
-    let values = synthesize(1_000_000);
+    let values = synthesize(1_000);
     let sum = values.iter().fold(0, |acc, Int(x)| acc + x);
     let mut window = Window::new();
     for v in values.clone() {
@@ -60,13 +60,13 @@ where
     assert_eq!(window.query(), Int(0));
 }
 
-/// Tries to find the maximum value out 1M randomly generated integers.
+/// Tries to find the maximum value out 1K randomly generated integers.
 fn test3<Window>()
 where
     Window: FifoWindow<Int, Max>,
 {
     let mut window = Window::new();
-    let values = synthesize(1_000_000);
+    let values = synthesize(1_000);
     let max = values.iter().map(|Int(x)| *x).max().unwrap();
     for v in values.clone() {
         window.push(v);
@@ -78,13 +78,13 @@ where
     assert_eq!(window.query(), Int(std::i64::MIN));
 }
 
-/// Fills a window with 1M elements and pushes/pops/queries 1M times.
+/// Fills a window with 1K elements and pushes/pops/queries 1K times.
 fn test4<Window>()
 where
     Window: FifoWindow<Int, Sum>,
 {
     let mut window = Window::new();
-    let values = synthesize((2 as u64).pow(22) as usize);
+    let values = synthesize(1_000);
     let sum = values.iter().fold(0, |acc, Int(x)| acc + x);
     for v in values.clone() {
         window.push(v);

--- a/rust/tests/fifo_window.rs
+++ b/rust/tests/fifo_window.rs
@@ -126,10 +126,25 @@ where
     window.pop();
 }
 
+/// Pops more elements from a window than what it contains.
+fn test6<Window>()
+where
+    Window: FifoWindow<Int, Sum>,
+{
+    let mut window = Window::new();
+    window.push(Int(1));
+    window.push(Int(2));
+    window.push(Int(3));
+    window.pop();
+    window.push(Int(4));
+    window.push(Int(5));
+}
+
 test_matrix! {
     test1 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks ],
     test2 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks ],
     test3 => [ recalc::ReCalc,           reactive::Reactive, two_stacks::TwoStacks ],
     test4 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks ],
-    test5 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks ]
+    test5 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks ],
+    test6 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks ]
 }

--- a/rust/tests/fifo_window.rs
+++ b/rust/tests/fifo_window.rs
@@ -1,12 +1,28 @@
 use rand::Rng;
-use swag::reactive::*;
-use swag::recalc::*;
-use swag::soe::*;
-use swag::two_stacks::*;
 use swag::*;
 
 mod common;
 use common::*;
+
+/// Macro for generating test cases for different algorithms.
+macro_rules! test_matrix {
+    {
+        $(
+            $name:ident => [$($module:ident::$algorithm:ident),*]
+        ),*
+    } => {
+        $(
+            mod $name {
+                $(
+                    #[test]
+                    fn $module() {
+                        super::$name::<swag::$module::$algorithm<_,_>>();
+                    }
+                )*
+            }
+        )*
+    }
+}
 
 /// Basic test for integer sums.
 fn test1<Window>()
@@ -92,81 +108,28 @@ where
     for v in values {
         window.push(v);
         window.pop();
+        window.query();
         assert_eq!(window.query(), Int(sum));
     }
 }
 
-#[test]
-fn test1_recalc() {
-    test1::<ReCalc<_, _>>();
+/// Pops more elements from a window than what it contains.
+fn test5<Window>()
+where
+    Window: FifoWindow<Int, Sum>,
+{
+    let mut window = Window::new();
+    window.push(Int(0));
+    window.push(Int(0));
+    window.pop();
+    window.pop();
+    window.pop();
 }
 
-#[test]
-fn test2_recalc() {
-    test2::<ReCalc<_, _>>();
-}
-
-#[test]
-fn test3_recalc() {
-    test3::<ReCalc<_, _>>();
-}
-
-#[test]
-fn test4_recalc() {
-    test4::<ReCalc<_, _>>();
-}
-
-#[test]
-fn test1_soe() {
-    test1::<SoE<_, _>>();
-}
-
-#[test]
-fn test2_soe() {
-    test2::<SoE<_, _>>();
-}
-
-#[test]
-fn test4_soe() {
-    test4::<SoE<_, _>>();
-}
-
-#[test]
-fn test1_two_stacks() {
-    test1::<TwoStacks<_, _>>();
-}
-
-#[test]
-fn test2_two_stacks() {
-    test2::<TwoStacks<_, _>>();
-}
-
-#[test]
-fn test3_two_stacks() {
-    test3::<TwoStacks<_, _>>();
-}
-
-#[test]
-fn test4_two_stacks() {
-    test4::<TwoStacks<_, _>>();
-}
-
-#[test]
-fn test1_reactive() {
-    test1::<Reactive<_, _>>();
-}
-
-#[test]
-fn test2_reactive() {
-    test2::<Reactive<_, _>>();
-}
-
-#[test]
-fn test3_reactive() {
-    test3::<Reactive<_, _>>();
-}
-
-#[test]
-fn test4_reactive() {
-    test4::<Reactive<_, _>>();
+test_matrix! {
+    test1 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks ],
+    test2 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks ],
+    test3 => [ recalc::ReCalc,           reactive::Reactive, two_stacks::TwoStacks ],
+    test4 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks ],
+    test5 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks ]
 }

--- a/rust/tests/fifo_window.rs
+++ b/rust/tests/fifo_window.rs
@@ -48,7 +48,7 @@ where
     Window: FifoWindow<Int, Sum>,
 {
     let values = generate();
-    let sum: i32 = values.iter().fold(0, |acc, Int(x)| acc + x);
+    let sum = values.iter().fold(0, |acc, Int(x)| acc + x);
     let mut window = Window::new();
     for v in values.clone() {
         window.push(v);
@@ -75,7 +75,7 @@ where
     for _ in values {
         window.pop();
     }
-    assert_eq!(window.query(), Int(std::i32::MIN));
+    assert_eq!(window.query(), Int(std::i64::MIN));
 }
 
 #[test]

--- a/rust/tests/fifo_window.rs
+++ b/rust/tests/fifo_window.rs
@@ -98,75 +98,75 @@ where
 
 #[test]
 fn test1_recalc() {
-    test1::<ReCalc<Int, Sum>>();
+    test1::<ReCalc<_, _>>();
 }
 
 #[test]
 fn test2_recalc() {
-    test2::<ReCalc<Int, Sum>>();
+    test2::<ReCalc<_, _>>();
 }
 
 #[test]
 fn test3_recalc() {
-    test3::<ReCalc<Int, Max>>();
+    test3::<ReCalc<_, _>>();
 }
 
 #[test]
 fn test4_recalc() {
-    test4::<ReCalc<Int, Sum>>();
+    test4::<ReCalc<_, _>>();
 }
 
 #[test]
 fn test1_soe() {
-    test1::<SoE<Int, Sum>>();
+    test1::<SoE<_, _>>();
 }
 
 #[test]
 fn test2_soe() {
-    test2::<SoE<Int, Sum>>();
+    test2::<SoE<_, _>>();
 }
 
 #[test]
 fn test4_soe() {
-    test4::<SoE<Int, Sum>>();
+    test4::<SoE<_, _>>();
 }
 
 #[test]
 fn test1_two_stacks() {
-    test1::<TwoStacks<Int, Sum>>();
+    test1::<TwoStacks<_, _>>();
 }
 
 #[test]
 fn test2_two_stacks() {
-    test2::<TwoStacks<Int, Sum>>();
+    test2::<TwoStacks<_, _>>();
 }
 
 #[test]
 fn test3_two_stacks() {
-    test3::<TwoStacks<Int, Max>>();
+    test3::<TwoStacks<_, _>>();
 }
 
 #[test]
 fn test4_two_stacks() {
-    test4::<TwoStacks<Int, Sum>>();
+    test4::<TwoStacks<_, _>>();
 }
 
 #[test]
 fn test1_reactive() {
-    test1::<Reactive<Int, Sum>>();
+    test1::<Reactive<_, _>>();
 }
 
 #[test]
 fn test2_reactive() {
-    test2::<Reactive<Int, Sum>>();
+    test2::<Reactive<_, _>>();
 }
 
 #[test]
 fn test3_reactive() {
-    test3::<Reactive<Int, Max>>();
+    test3::<Reactive<_, _>>();
 }
 
 #[test]
 fn test4_reactive() {
-    test4::<Reactive<Int, Sum>>();
+    test4::<Reactive<_, _>>();
 }


### PR DESCRIPTION
This PR contains a couple of minor improvements. The most important change is in Reactive. I found a bug in my implementation which only happens when FlatFat contains only one element which is both a leaf and a root node. When updating a leaf node, I need to access its parent. The program crashed because the root node has no parent. Reactive now ensures that a leaf cannot be a root by never resizing if there is only one element in the window. This is the part of the Reactive algorithm I'm referring to. The bug happened when `leaf(loci) = T.root`.

![image](https://user-images.githubusercontent.com/15143039/87856119-19a99480-c91d-11ea-96d4-a7462e7e23e4.png)

I realised I also somehow forgot to make the Reactive-FlatFat buffer circular 👀 It should be fixed now.

The PR in addition adds some small extension methods to FifoWindows:
* Added `len` method for calculating the number of elements in a window.
* Added `is_empty` method for calculating if a window is empty.