### PR TITLE
Add Rust implementation for FlatFIT

### DIFF
--- a/rust/src/flatfit/mod.rs
+++ b/rust/src/flatfit/mod.rs
@@ -1,0 +1,126 @@
+use crate::FifoWindow;
+use alga::general::AbstractMonoid;
+use alga::general::Operator;
+use std::marker::PhantomData;
+
+const LOW_CAP: usize = 2;
+
+#[derive(Clone)]
+pub struct FlatFIT<Value, BinOp>
+where
+    Value: AbstractMonoid<BinOp> + Clone,
+    BinOp: Operator,
+{
+    front: usize,
+    back: usize,
+    size: usize,
+    buffer: Vec<Item<Value>>,
+    binop: PhantomData<BinOp>,
+}
+
+#[derive(Clone)]
+struct Item<Value> {
+    val: Value,
+    next: usize,
+}
+
+impl<Value> Item<Value> {
+    fn new(val: Value, next: usize) -> Self {
+        Self { val, next }
+    }
+}
+
+impl<Value, BinOp> FifoWindow<Value, BinOp> for FlatFIT<Value, BinOp>
+where
+    Value: AbstractMonoid<BinOp> + Clone,
+    BinOp: Operator,
+{
+    fn new() -> Self {
+        Self {
+            front: 0,
+            back: 0,
+            size: 0,
+            buffer: Vec::new(),
+            binop: PhantomData,
+        }
+    }
+    fn push(&mut self, val: Value) {
+        if self.size + 1 > self.buffer.len() {
+            self.rescale(self.buffer.len() * 2)
+        }
+        self.size += 1;
+        let prev = self.back;
+        self.back = (self.back + 1) % self.size;
+        self.buffer[self.back].val = val;
+        self.buffer[prev].next = self.back;
+    }
+    fn pop(&mut self) -> Option<Value> {
+        if self.size > 0 {
+            let item = self.buffer.get(self.front).map(|item| item.val.clone());
+            self.front = (self.front + 1) % self.buffer.capacity();
+            self.size -= 1;
+            if self.size < self.buffer.len() / 2 {
+                self.rescale(self.buffer.len() / 2)
+            }
+            item
+        } else {
+            None
+        }
+    }
+    fn query(&self) -> Value {
+        let mut agg = Value::identity();
+        if self.size > 0 {
+            let mut tracing_indices = Vec::new();
+            let mut current = self.front;
+            while current != self.back {
+                tracing_indices.push(current);
+                current = self.buffer[current].next;
+            }
+            unsafe {
+                // FlatFIT queries mutate the internal buffer
+                let buffer = &self.buffer as *const Vec<Item<Value>> as *mut Vec<Item<Value>>;
+                while let Some(i) = tracing_indices.pop() {
+                    agg = agg.operate(&self.buffer[i].val);
+                    (*buffer)[i] = Item::new(agg.clone(), self.back);
+                }
+            }
+            agg = agg.operate(&self.buffer[self.back].val);
+        }
+        agg
+    }
+    fn len(&self) -> usize {
+        self.size
+    }
+    fn is_empty(&self) -> bool {
+        self.size == 0
+    }
+}
+
+impl<Value, BinOp> FlatFIT<Value, BinOp>
+where
+    Value: AbstractMonoid<BinOp> + Clone,
+    BinOp: Operator,
+{
+    fn rescale(&mut self, new_capacity: usize) {
+        let new_capacity = std::cmp::max(new_capacity, LOW_CAP);
+        let mut new_buffer: Vec<Item<Value>> = Vec::with_capacity(new_capacity);
+        unsafe {
+            // Unsafe is used here so we don't need to initialize the buffer's contents
+            new_buffer.set_len(new_capacity);
+        }
+        let old_capacity = self.buffer.capacity();
+        for i in 0..self.size {
+            let item = &self.buffer[(self.front + i) % old_capacity];
+            let offset = (item.next + old_capacity - self.front) % old_capacity;
+            new_buffer[i].val = item.val.clone();
+            new_buffer[i].next = offset;
+        }
+        self.buffer = new_buffer;
+        self.front = 0;
+        if self.size == 0 {
+            self.back = 0;
+        } else {
+            self.back = self.size - 1
+        }
+    }
+}

--- a/rust/src/flatfit/mod.rs
+++ b/rust/src/flatfit/mod.rs
@@ -16,6 +16,7 @@ where
     back: usize,
     size: usize,
     buffer: RefCell<Vec<Item<Value>>>,
+    tracing_indices: RefCell<Vec<usize>>,
     binop: PhantomData<BinOp>,
 }
 
@@ -42,6 +43,7 @@ where
             back: 0,
             size: 0,
             buffer: RefCell::new(Vec::new()),
+            tracing_indices: RefCell::new(Vec::new()),
             binop: PhantomData,
         }
     }
@@ -75,7 +77,8 @@ where
         let mut agg = Value::identity();
         let mut buffer = self.buffer.borrow_mut();
         if self.size > 0 {
-            let mut tracing_indices = Vec::new();
+            let mut tracing_indices = self.tracing_indices.borrow_mut();
+            debug_assert!(tracing_indices.is_empty());
             let mut current = self.front;
             while current != self.back {
                 tracing_indices.push(current);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -57,3 +57,5 @@ pub mod two_stacks;
 /// Reactive-Aggregator
 pub mod reactive;
 
+/// Flat and Fast Index Traverser
+pub mod flatfit;

--- a/rust/tests/fifo_window.rs
+++ b/rust/tests/fifo_window.rs
@@ -139,11 +139,50 @@ where
     window.push(Int(5));
 }
 
+/// Push => Query
+fn test7<Window>()
+where
+    Window: FifoWindow<Int, Sum>,
+{
+    let mut window = Window::new();
+    window.push(Int(1));
+    assert_eq!(window.query(), Int(1));
+}
+
+/// Push => Push => Push => Pop => Pop => Query
+fn test8<Window>()
+where
+    Window: FifoWindow<Int, Sum>,
+{
+    let mut window = Window::new();
+    window.push(Int(1));
+    window.push(Int(2));
+    window.push(Int(3));
+    window.pop();
+    window.pop();
+    assert_eq!(window.query(), Int(3));
+}
+
+/// Push => Pop => Push => Query
+fn test9<Window>()
+where
+    Window: FifoWindow<Int, Sum>,
+{
+    let mut window = Window::new();
+    window.push(Int(1));
+    window.pop();
+    window.push(Int(2));
+    assert_eq!(window.query(), Int(2));
+}
+
 test_matrix! {
-    test1 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks ],
-    test2 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks ],
-    test3 => [ recalc::ReCalc,           reactive::Reactive, two_stacks::TwoStacks ],
-    test4 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks ],
-    test5 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks ],
-    test6 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks ]
+    test1 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, flatfit::FlatFIT ],
+    test2 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, flatfit::FlatFIT ],
+    test3 => [ recalc::ReCalc,           reactive::Reactive, two_stacks::TwoStacks, flatfit::FlatFIT ],
+    test4 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, flatfit::FlatFIT ],
+    test5 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, flatfit::FlatFIT ],
+    test6 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, flatfit::FlatFIT ],
+    test7 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, flatfit::FlatFIT ],
+    test8 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, flatfit::FlatFIT ],
+    test9 => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, flatfit::FlatFIT ]
 }


### PR DESCRIPTION
This is a Rust implementation of the dynamic FlatFIT algorithm based on your C++ implementation. I went with `std::vec::Vec` for storing the internal buffer, but I think it might be possible to also use `std::vec::VecDeque`.