### PR TITLE
Further improvements to "implicit" two-stacks lite

### DIFF
--- a/cpp/src/ImplicitTwoStacksLite.hpp
+++ b/cpp/src/ImplicitTwoStacksLite.hpp
@@ -4,6 +4,7 @@
 #include<iterator>
 #include<cassert>
 #include "RingBufferQueue.hpp"
+#include "ChunkedArrayQueue.hpp"
 
 namespace implicit_twostackslite {
     using namespace std;
@@ -64,16 +65,16 @@ namespace implicit_twostackslite {
         inline void flip() {
             // std::cerr << "evict: flippping" << std::endl;
             // front is empty, let's turn the "stack" implicity.
-            iterT it = _q.end() - 1;
+            iterT it = _q.end();
             size_t n = size();
             aggT running_sum = _identE;
             // std::cerr << "evict: ++++ (initial) running_sum " << running_sum << std::endl;
             for (size_t rep=0;rep<n;rep++) {
                 // std::cerr << "evict: ++++ val " << local_agg._val << " ";
+                --it;
                 running_sum = _binOp.combine(it->_val, running_sum);
                 // std::cerr << "running_sum " << running_sum << std::endl;
                 it->_val = running_sum;
-                --it;
             }
             // reset the "back" stack
             _backSum = _identE;
@@ -88,6 +89,50 @@ namespace implicit_twostackslite {
         aggT _backSum;
         aggT _identE;
     };
+
+    template <class BinaryFunction, class T>
+    Aggregate<BinaryFunction> make_aggregate(BinaryFunction f, T elem) {
+        return Aggregate<BinaryFunction>(f, elem);
+    }
+
+    template <typename BinaryFunction>
+    struct MakeAggregate {
+        template <typename T>
+        Aggregate<BinaryFunction> operator()(T elem) {
+            BinaryFunction f;
+            return make_aggregate(f, elem);
+        }
+    };
+}
+
+namespace rb_twostackslite {
+
+    template<typename binOpFunc>
+        using Aggregate = implicit_twostackslite::Aggregate <
+            binOpFunc,
+            RingBufferQueue<implicit_twostackslite::__AggT<typename binOpFunc::Partial> > >;
+
+    template <class BinaryFunction, class T>
+    Aggregate<BinaryFunction> make_aggregate(BinaryFunction f, T elem) {
+        return Aggregate<BinaryFunction>(f, elem);
+    }
+
+    template <typename BinaryFunction>
+    struct MakeAggregate {
+        template <typename T>
+        Aggregate<BinaryFunction> operator()(T elem) {
+            BinaryFunction f;
+            return make_aggregate(f, elem);
+        }
+    };
+}
+
+namespace chunked_twostackslite {
+
+    template<typename binOpFunc>
+        using Aggregate = implicit_twostackslite::Aggregate <
+            binOpFunc,
+            ChunkedArrayQueue<implicit_twostackslite::__AggT<typename binOpFunc::Partial> > >;
 
     template <class BinaryFunction, class T>
     Aggregate<BinaryFunction> make_aggregate(BinaryFunction f, T elem) {

--- a/cpp/src/ImplicitTwoStacksLite.hpp
+++ b/cpp/src/ImplicitTwoStacksLite.hpp
@@ -56,12 +56,7 @@ namespace implicit_twostackslite {
         }
     private:
         inline bool front_empty() { return _num_flipped == 0; }
-        inline int decr(int it) {
-            it--;
-            if (it < 0)
-                it += _q._rb->capacity;
-            return it;
-        }
+
         inline void flip() {
             // std::cerr << "evict: flippping" << std::endl;
             // front is empty, let's turn the "stack" implicity.

--- a/cpp/src/ImplicitTwoStacksLite.hpp
+++ b/cpp/src/ImplicitTwoStacksLite.hpp
@@ -64,17 +64,16 @@ namespace implicit_twostackslite {
         inline void flip() {
             // std::cerr << "evict: flippping" << std::endl;
             // front is empty, let's turn the "stack" implicity.
-            int it = decr(_q._rb->back);
+            iterT it = _q.end() - 1;
             size_t n = size();
             aggT running_sum = _identE;
             // std::cerr << "evict: ++++ (initial) running_sum " << running_sum << std::endl;
             for (size_t rep=0;rep<n;rep++) {
-                AggT &local_agg = _q._rb->buffer[it];
                 // std::cerr << "evict: ++++ val " << local_agg._val << " ";
-                running_sum = _binOp.combine(local_agg._val, running_sum);
+                running_sum = _binOp.combine(it->_val, running_sum);
                 // std::cerr << "running_sum " << running_sum << std::endl;
-                local_agg._val = running_sum;
-                it = decr(it);
+                it->_val = running_sum;
+                --it;
             }
             // reset the "back" stack
             _backSum = _identE;

--- a/cpp/src/TimestampedImplicitTwoStacksLite.hpp
+++ b/cpp/src/TimestampedImplicitTwoStacksLite.hpp
@@ -4,6 +4,7 @@
 #include<iterator>
 #include<cassert>
 #include "RingBufferQueue.hpp"
+#include "ChunkedArrayQueue.hpp"
 
 namespace timestamped_implicit_twostackslite {
     using namespace std;
@@ -29,7 +30,7 @@ namespace timestamped_implicit_twostackslite {
         typedef Timestamp timeT;
         typedef __AggT<aggT, timeT> AggT;
 
-        Aggregate(binOpFunc binOp_, aggT identE_) 
+        Aggregate(binOpFunc binOp_, aggT identE_)
             : _q(), _num_flipped(0), _binOp(binOp_), _backSum(identE_), _identE(identE_) {}
 
         size_t size() { return _q.size(); }
@@ -40,24 +41,9 @@ namespace timestamped_implicit_twostackslite {
             _q.push_back(AggT(lifted, time));
         }
 
-        void evict() { 
-            if (front_empty()) {
-                // std::cerr << "evict: flippping" << std::endl;
-                // front is empty, let's turn the "stack" implicity.
-                iterT front = _q.begin();
-                iterT it = _q.end()-1;
-                aggT running_sum = _identE;
-                // std::cerr << "evict: ++++ (initial) running_sum " << running_sum << std::endl;
-                while (it != front) {
-                    // std::cerr << "evict: ++++ val " << it->_val << " ";
-                    running_sum = _binOp.combine(it->_val, running_sum);
-                    it->_val = running_sum;
-                    // std::cerr << "running_sum " << running_sum << std::endl;
-                    --it;
-                }
-                _backSum = _identE;
-                _num_flipped = size();
-            }
+        void evict() {
+            if (front_empty())
+                flip();
             _q.pop_front();
             _num_flipped--;
         }
@@ -78,6 +64,25 @@ namespace timestamped_implicit_twostackslite {
     private:
         inline bool front_empty() { return _num_flipped == 0; }
 
+        inline void flip() {
+            // std::cerr << "evict: flippping" << std::endl;
+            // front is empty, let's turn the "stack" implicity.
+            iterT it = _q.end();
+            size_t n = size();
+            aggT running_sum = _identE;
+            // std::cerr << "evict: ++++ (initial) running_sum " << running_sum << std::endl;
+            for (size_t rep=0;rep<n;rep++) {
+                // std::cerr << "evict: ++++ val " << local_agg._val << " ";
+                --it;
+                running_sum = _binOp.combine(it->_val, running_sum);
+                // std::cerr << "running_sum " << running_sum << std::endl;
+                it->_val = running_sum;
+            }
+            // reset the "back" stack
+            _backSum = _identE;
+            _num_flipped = n;
+        }
+
         queueT _q;
         typedef typename queueT::iterator iterT;
         size_t _num_flipped;
@@ -86,6 +91,66 @@ namespace timestamped_implicit_twostackslite {
         aggT _backSum;
         aggT _identE;
     };
+
+    template <typename timeT, class BinaryFunction, class T>
+    Aggregate<BinaryFunction, timeT> make_aggregate(BinaryFunction f, T elem) {
+        return Aggregate<BinaryFunction, timeT>(f, elem);
+    }
+
+    template <typename BinaryFunction, typename timeT>
+    struct MakeAggregate {
+        template <typename T>
+        Aggregate<BinaryFunction, timeT> operator()(T elem) {
+            BinaryFunction f;
+            return make_aggregate<timeT, BinaryFunction>(f, elem);
+        }
+    };
+}
+
+namespace timestamped_rb_twostackslite {
+    template<typename binOpFunc,
+             typename Timestamp>
+        using Aggregate = timestamped_implicit_twostackslite::Aggregate <
+            binOpFunc,
+            Timestamp,
+            RingBufferQueue<
+                timestamped_implicit_twostackslite::__AggT<
+                    typename binOpFunc::Partial, 
+                    Timestamp
+                > 
+            > 
+        >;
+
+
+    template <typename timeT, class BinaryFunction, class T>
+    Aggregate<BinaryFunction, timeT> make_aggregate(BinaryFunction f, T elem) {
+        return Aggregate<BinaryFunction, timeT>(f, elem);
+    }
+
+    template <typename BinaryFunction, typename timeT>
+    struct MakeAggregate {
+        template <typename T>
+        Aggregate<BinaryFunction, timeT> operator()(T elem) {
+            BinaryFunction f;
+            return make_aggregate<timeT, BinaryFunction>(f, elem);
+        }
+    };
+}
+
+namespace timestamped_chunked_twostackslite {
+    template<typename binOpFunc,
+             typename Timestamp>
+        using Aggregate = timestamped_implicit_twostackslite::Aggregate <
+            binOpFunc,
+            Timestamp,
+            RingBufferQueue<
+                timestamped_implicit_twostackslite::__AggT<
+                    typename binOpFunc::Partial, 
+                    Timestamp
+                > 
+            > 
+        >;
+
 
     template <typename timeT, class BinaryFunction, class T>
     Aggregate<BinaryFunction, timeT> make_aggregate(BinaryFunction f, T elem) {

--- a/cpp/src/benchmark_driver.cc
+++ b/cpp/src/benchmark_driver.cc
@@ -88,7 +88,8 @@ int main(int argc, char** argv) {
           query_call_benchmark<aba::MakeAggregate>("aba", aggregator, function, exp) ||
           query_call_benchmark<twostacks::MakeAggregate>("two_stacks", aggregator, function, exp) ||
           query_call_benchmark<twostackslite::MakeAggregate>("two_stacks_lite", aggregator, function, exp) ||
-          query_call_benchmark<implicit_twostackslite::MakeAggregate>("im_two_stacks_lite", aggregator, function, exp) ||
+          query_call_benchmark<rb_twostackslite::MakeAggregate>("rb_two_stacks_lite", aggregator, function, exp) ||
+          query_call_benchmark<chunked_twostackslite::MakeAggregate>("chunked_two_stacks_lite", aggregator, function, exp) ||
           query_call_benchmark<dynamic_flatfit::MakeAggregate>("flatfit", aggregator, function, exp) ||
           query_call_benchmark<reactive::MakeAggregate>("reactive", aggregator, function, exp) ||
           query_call_benchmark<recalc::MakeAggregate>("recalc", aggregator, function, exp) ||

--- a/cpp/src/data_benchmark.cc
+++ b/cpp/src/data_benchmark.cc
@@ -67,7 +67,8 @@ void call_benchmarks(std::ifstream& in, int samples, const std::string& data_set
 
                   query_call_data_benchmark<DataSet, timestamped_twostacks::MakeAggregate>("two_stacks", aggregator, function, exp, gen, out) ||
                   query_call_data_benchmark<DataSet, timestamped_twostacks_lite::MakeAggregate>("two_stacks_lite", aggregator, function, exp, gen, out) ||
-                  query_call_data_benchmark<DataSet, timestamped_implicit_twostackslite::MakeAggregate>("im_two_stacks_lite", aggregator, function, exp, gen, out) ||
+                  query_call_data_benchmark<DataSet, timestamped_rb_twostackslite::MakeAggregate>("rb_two_stacks_lite", aggregator, function, exp, gen, out) ||
+                  query_call_data_benchmark<DataSet, timestamped_chunked_twostackslite::MakeAggregate>("chunked_two_stacks_lite", aggregator, function, exp, gen, out) ||
                   query_call_data_benchmark<DataSet, timestamped_dynamic_flatfit::MakeAggregate>("flatfit", aggregator, function, exp, gen, out) ||
                   query_call_data_benchmark<DataSet, timestamped_daba::MakeAggregate, false>("daba", aggregator, function, exp, gen, out) ||
                   query_call_data_benchmark<DataSet, timestamped_dabalite::MakeAggregate>("daba_lite", aggregator, function, exp, gen, out)

--- a/cpp/src/ringbuffertest.cc
+++ b/cpp/src/ringbuffertest.cc
@@ -5,8 +5,10 @@
 void printUsingIter(RingBufferQueue<int> &rb) {
     RingBufferQueue<int>::iterator it = rb.begin();
 
-    std::cout << "|> " << it.aap << std::endl;
-    std::cout << ">| " << rb.end().aap << std::endl;
+    // std::cout << "|> " << it.aap << std::endl;
+    // std::cout << ">| " << rb.end().aap << std::endl;
+    std::cout << "|> " << (it.it - it.rb->buffer) << ", "; // std::endl;
+    std::cout << ">| " << (rb.end().it - it.rb->buffer) << std::endl;
     
     while (it != rb.end()) {
         std::cout << (*it)  << " ";
@@ -20,29 +22,38 @@ int main(int argc, char const *argv[])
     RingBufferQueue<int> rb;
 
     int pb[] = {3, 1, 4, 9, 2, 6};
-    RingBufferQueue<int>::iterator fix4;
     for (auto val: pb) {
         rb.push_back(val);
-        std::cout << rb.front() << " " << rb.back() << std::endl;
+        std::cout << "#++" << rb.front() << " " << rb.back() << std::endl;
         printUsingIter(rb);
         std::cout << "++++++" << std::endl;
-        if (val == 4) {
-            fix4 = rb.end() - 1;
-        }
+    }
+
+    while (rb.size() > 0) {
+        std::cout<< "#--"  << rb.front() << " " << rb.back() << std::endl;
+        rb.pop_front();
+        printUsingIter(rb);
+        // std::cout << "fix4: " << (*fix4) << std::endl;
+        // std::cout << "++++++" << std::endl;
+    }
+
+    for (auto val: pb) {
+        rb.push_back(val);
+        std::cout << "#++" << rb.front() << " " << rb.back() << std::endl;
+        printUsingIter(rb);
+        std::cout << "++++++" << std::endl;
+    }
+    while (rb.size() > 0) {
+        std::cout << "#--" << rb.front() << " " << rb.back() << std::endl;
+        rb.pop_front();
+        printUsingIter(rb);
     }
 
     RingBufferQueue<int>::iterator eob = rb.end();
-    while (rb.size() > 0) {
-        std::cout << rb.front() << " " << rb.back() << std::endl;
-        rb.pop_front();
-        printUsingIter(rb);
-        std::cout << "fix4: " << (*fix4) << std::endl;
-        std::cout << "++++++" << std::endl;
-    }
 
-    std::cout << "rb.capacity=" << rb._rb->capacity << ", end.aap=" << rb.end().aap 
-    << ", begin.aap=" << rb.begin().aap
-    << ", eob.aap=" << eob.aap << std::endl;
+    std::cout << "rb.capacity=" << rb._rb->capacity << ", end.it=" << rb.end().it 
+    << ", begin.it=" << rb.begin().it
+    << ", eob.it=" << eob.it << std::endl;
 
     std::cout << "---------------" << std::endl;
 

--- a/cpp/src/test.cc
+++ b/cpp/src/test.cc
@@ -610,7 +610,8 @@ void test_timestamped_fifo(F f, typename F::Partial identity, uint64_t iteration
     auto daba_lite_agg = timestampedfifo::make_aggregate<timestamp, dabalite::Aggregate<F>>(f, identity);
     auto twostacks_agg = timestampedfifo::make_aggregate<timestamp, twostacks::Aggregate<F>>(f, identity);
     auto twostacks_lite_agg = timestampedfifo::make_aggregate<timestamp, twostackslite::Aggregate<F>>(f, identity);
-    auto implicit_twostacks_lite_agg = timestamped_implicit_twostackslite::make_aggregate<timestamp, F>(f, identity);
+    auto rb_twostacks_lite_agg = timestamped_rb_twostackslite::make_aggregate<timestamp, F>(f, identity);
+    auto chunked_twostacks_lite_agg = timestamped_chunked_twostackslite::make_aggregate<timestamp, F>(f, identity);
     auto flatfit_agg = timestampedfifo::make_aggregate<timestamp, flatfit::Aggregate<F>>(f, identity);
     auto recalc_agg = timestampedfifo::make_aggregate<timestamp, recalc::Aggregate<F>>(f, identity);
     auto bclassic_agg = btree::make_aggregate<timestamp, 2, btree::classic>(f, identity);
@@ -622,7 +623,8 @@ void test_timestamped_fifo(F f, typename F::Partial identity, uint64_t iteration
         real_assert(sz == daba_lite_agg.size(), name + ": recalc size != daba_lite");
         real_assert(sz == twostacks_agg.size(), name + ": recalc size != two_stacks");
         real_assert(sz == twostacks_lite_agg.size(), name + ": recalc size != two_stacks_lite");
-        real_assert(sz == implicit_twostacks_lite_agg.size(), name + ": recalc size != implicit_two_stacks_lite");
+        real_assert(sz == rb_twostacks_lite_agg.size(), name + ": recalc size != rb_two_stacks_lite");
+        real_assert(sz == chunked_twostacks_lite_agg.size(), name + ": recalc size != chunked_two_stacks_lite");
         real_assert(sz == flatfit_agg.size(), name + ": recalc size != flatfit");
         real_assert(sz == bclassic_agg.size(), name + ": recalc size != bclassic");
         real_assert(sz == bfinger_agg.size(), name + ": recalc size != bfinger");
@@ -632,7 +634,8 @@ void test_timestamped_fifo(F f, typename F::Partial identity, uint64_t iteration
             daba_lite_agg.evict();
             twostacks_agg.evict();
             twostacks_lite_agg.evict();
-            implicit_twostacks_lite_agg.evict();
+            rb_twostacks_lite_agg.evict();
+            chunked_twostacks_lite_agg.evict();            
             flatfit_agg.evict();
             recalc_agg.evict();
             bclassic_agg.evict();
@@ -644,7 +647,8 @@ void test_timestamped_fifo(F f, typename F::Partial identity, uint64_t iteration
         daba_lite_agg.insert(i, i);
         twostacks_agg.insert(i, i);
         twostacks_lite_agg.insert(i, i);
-        implicit_twostacks_lite_agg.insert(i, i);
+        rb_twostacks_lite_agg.insert(i, i);
+        chunked_twostacks_lite_agg.insert(i, i);
         flatfit_agg.insert(i, i);
         bclassic_agg.insert(i, i);
         bfinger_agg.insert(i, i);
@@ -654,7 +658,8 @@ void test_timestamped_fifo(F f, typename F::Partial identity, uint64_t iteration
         real_assert(res == daba_lite_agg.query(), name + ": recalc != daba_lite");
         real_assert(res == twostacks_agg.query(), name + ": recalc != two_stacks");
         real_assert(res == twostacks_lite_agg.query(), name + ": recalc != two_stacks_lite");
-        real_assert(res == implicit_twostacks_lite_agg.query(), name + ": recalc != implicit_two_stacks_lite");
+        real_assert(res == rb_twostacks_lite_agg.query(), name + ": recalc != rb_two_stacks_lite");
+        real_assert(res == chunked_twostacks_lite_agg.query(), name + ": recalc != chunked_two_stacks_lite");
         real_assert(res == flatfit_agg.query(), name + ": recalc != flatfit");
         real_assert(res == bclassic_agg.query(), name + ": recalc != bclassic");
         real_assert(res == bfinger_agg.query(), name + ": recalc != bfinger");

--- a/cpp/src/test.cc
+++ b/cpp/src/test.cc
@@ -46,7 +46,8 @@ void test_alg_no_inverse(F f, typename F::Partial identity, uint64_t iterations,
     auto aba_agg = aba::make_aggregate(f, identity);
     auto twostacks_agg = twostacks::make_aggregate(f, identity);
     auto twostacks_lite_agg = twostackslite::make_aggregate(f, identity);
-    auto implicit_twostacks_lite_agg = implicit_twostackslite::make_aggregate(f, identity);
+    auto rb_twostacks_lite_agg = rb_twostackslite::make_aggregate(f, identity);
+    auto chunked_twostacks_lite_agg = chunked_twostackslite::make_aggregate(f, identity);
     auto flatfit_agg = flatfit::make_aggregate(f, identity);
     auto dyn_flatfit_agg = dynamic_flatfit::make_aggregate(f, identity);
     auto recalc_agg = recalc::make_aggregate(f, identity);
@@ -63,14 +64,15 @@ void test_alg_no_inverse(F f, typename F::Partial identity, uint64_t iterations,
         real_assert(sz == aba_agg.size(), name + ": recalc size != aba");
         real_assert(sz == twostacks_agg.size(), name + ": recalc size != two_stacks");
         real_assert(sz == twostacks_lite_agg.size(), name + ": recalc size != two_stacks_lite");
-        real_assert(sz == implicit_twostacks_lite_agg.size(), name + ": recalc size != implicit_two_stacks_lite");
+        real_assert(sz == rb_twostacks_lite_agg.size(), name + ": recalc size != rb_two_stacks_lite");
+        real_assert(sz == chunked_twostacks_lite_agg.size(), name + ": recalc size != chunked_two_stacks_lite");
         real_assert(sz == flatfit_agg.size(), name + ": recalc size != flatfit");
         real_assert(sz == dyn_flatfit_agg.size(), name + ": recalc size != dyn_flatfit");
         real_assert(sz == reactive_agg.size(), name + ": recalc size != reactive");
         real_assert(sz == okasakis_agg.size(), name + ": recalc size != okasaki");
         real_assert(sz == bclassic_agg.size(), name + ": recalc size != bclassic");
         real_assert(sz == bknuckle_agg.size(), name + ": recalc size != bknuckle");
-        real_assert(sz == bfinger_agg.size(), name + ": recalc size != bfinger");        
+        real_assert(sz == bfinger_agg.size(), name + ": recalc size != bfinger");
 
         if (recalc_agg.size() == window_size) {
             daba_agg.evict();
@@ -78,7 +80,8 @@ void test_alg_no_inverse(F f, typename F::Partial identity, uint64_t iterations,
             aba_agg.evict();
             twostacks_agg.evict();
             twostacks_lite_agg.evict();
-            implicit_twostacks_lite_agg.evict();
+            rb_twostacks_lite_agg.evict();
+            chunked_twostacks_lite_agg.evict();
             flatfit_agg.evict();
             dyn_flatfit_agg.evict();
             recalc_agg.evict();
@@ -86,7 +89,7 @@ void test_alg_no_inverse(F f, typename F::Partial identity, uint64_t iterations,
             okasakis_agg.evict();
             bclassic_agg.evict();
             bknuckle_agg.evict();
-            bfinger_agg.evict();            
+            bfinger_agg.evict();
         }
 
         recalc_agg.insert(i);
@@ -95,7 +98,8 @@ void test_alg_no_inverse(F f, typename F::Partial identity, uint64_t iterations,
         aba_agg.insert(i);
         twostacks_agg.insert(i);
         twostacks_lite_agg.insert(i);
-        implicit_twostacks_lite_agg.insert(i);
+        rb_twostacks_lite_agg.insert(i);
+        chunked_twostacks_lite_agg.insert(i);
         flatfit_agg.insert(i);
         dyn_flatfit_agg.insert(i);
         reactive_agg.insert(i);
@@ -110,7 +114,8 @@ void test_alg_no_inverse(F f, typename F::Partial identity, uint64_t iterations,
         real_assert(res == aba_agg.query(), name + ": recalc != aba");
         real_assert(res == twostacks_agg.query(), name + ": recalc != two_stacks");
         real_assert(res == twostacks_lite_agg.query(), name + ": recalc != two_stacks_lite");
-        real_assert(res == implicit_twostacks_lite_agg.query(), name + ": recalc != implicit_two_stacks_lite");
+        real_assert(res == rb_twostacks_lite_agg.query(), name + ": recalc != rb_two_stacks_lite");
+        real_assert(res == chunked_twostacks_lite_agg.query(), name + ": recalc != chunked_two_stacks_lite");
         real_assert(res == flatfit_agg.query(), name + ": recalc != flatfit");
         real_assert(res == dyn_flatfit_agg.query(), name + ": recalc != dyn_flatfit");
         real_assert(res == reactive_agg.query(), name + ": recalc != reactive");
@@ -129,7 +134,8 @@ void test_alg_with_inverse(F f, typename F::Partial identity, uint64_t iteration
     auto aba_agg = aba::make_aggregate(f, identity);
     auto twostacks_agg = twostacks::make_aggregate(f, identity);
     auto twostacks_lite_agg = twostackslite::make_aggregate(f, identity);
-    auto implicit_twostacks_lite_agg = implicit_twostackslite::make_aggregate(f, identity);
+    auto rb_twostacks_lite_agg = rb_twostackslite::make_aggregate(f, identity);
+    auto chunked_twostacks_lite_agg = chunked_twostackslite::make_aggregate(f, identity);
     auto flatfit_agg = flatfit::make_aggregate(f, identity);
     auto dyn_flatfit_agg = dynamic_flatfit::make_aggregate(f, identity);
     auto soe_agg = soe::make_aggregate(f, identity);
@@ -146,7 +152,8 @@ void test_alg_with_inverse(F f, typename F::Partial identity, uint64_t iteration
         real_assert(sz == aba_agg.size(), name + ": recalc size != aba");
         real_assert(sz == twostacks_agg.size(), name + ": recalc size != two_stacks");
         real_assert(sz == twostacks_lite_agg.size(), name + ": recalc size != two_stacks_lite");
-        real_assert(sz == implicit_twostacks_lite_agg.size(), name + ": recalc size != implicit_two_stacks_lite");
+        real_assert(sz == rb_twostacks_lite_agg.size(), name + ": recalc size != rb_two_stacks_lite");
+        real_assert(sz == chunked_twostacks_lite_agg.size(), name + ": recalc size != chunked_two_stacks_lite");
         real_assert(sz == flatfit_agg.size(), name + ": recalc size != flatfit");
         real_assert(sz == dyn_flatfit_agg.size(), name + ": recalc size != dyn_flatfit");
         real_assert(sz == soe_agg.size(), name + ": recalc size != soe");
@@ -160,7 +167,8 @@ void test_alg_with_inverse(F f, typename F::Partial identity, uint64_t iteration
             aba_agg.evict();
             twostacks_agg.evict();
             twostacks_lite_agg.evict();
-            implicit_twostacks_lite_agg.evict();
+            rb_twostacks_lite_agg.evict();
+            chunked_twostacks_lite_agg.evict();
             flatfit_agg.evict();
             dyn_flatfit_agg.evict();
             soe_agg.evict();
@@ -177,7 +185,8 @@ void test_alg_with_inverse(F f, typename F::Partial identity, uint64_t iteration
         aba_agg.insert(i);
         twostacks_agg.insert(i);
         twostacks_lite_agg.insert(i);
-        implicit_twostacks_lite_agg.insert(i);
+        rb_twostacks_lite_agg.insert(i);
+        chunked_twostacks_lite_agg.insert(i);
         flatfit_agg.insert(i);
         dyn_flatfit_agg.insert(i);
         soe_agg.insert(i);
@@ -192,7 +201,8 @@ void test_alg_with_inverse(F f, typename F::Partial identity, uint64_t iteration
         real_assert(res == aba_agg.query(), name + ": recalc != aba");
         real_assert(res == twostacks_agg.query(), name + ": recalc != two_stacks");
         real_assert(res == twostacks_lite_agg.query(), name + ": recalc != two_stacks_lite");
-        real_assert(res == implicit_twostacks_lite_agg.query(), name + ": recalc != implicit_two_stacks_lite");
+        real_assert(res == rb_twostacks_lite_agg.query(), name + ": recalc != rb_two_stacks_lite");
+        real_assert(res == chunked_twostacks_lite_agg.query(), name + ": recalc != chunked_two_stacks_lite");
         real_assert(res == flatfit_agg.query(), name + ": recalc != flatfit");
         real_assert(res == dyn_flatfit_agg.query(), name + ": recalc != dyn_flatfit");
         real_assert(res == soe_agg.query(), name + ": recalc != soe");
@@ -214,7 +224,8 @@ void test_alg_no_inverse_sawtooth(F f, typename F::Partial identity,
   auto aba_agg = aba::make_aggregate(f, identity);
   auto twostacks_agg = twostacks::make_aggregate(f, identity);
   auto twostacks_lite_agg = twostackslite::make_aggregate(f, identity);
-  auto implicit_twostacks_lite_agg = implicit_twostackslite::make_aggregate(f, identity);
+  auto rb_twostacks_lite_agg = rb_twostackslite::make_aggregate(f, identity);
+  auto chunked_twostacks_lite_agg = chunked_twostackslite::make_aggregate(f, identity);
   auto flatfit_agg = flatfit::make_aggregate(f, identity);
   auto dyn_flatfit_agg = dynamic_flatfit::make_aggregate(f, identity);
   auto recalc_agg = recalc::make_aggregate(f, identity);
@@ -222,7 +233,7 @@ void test_alg_no_inverse_sawtooth(F f, typename F::Partial identity,
   auto bclassic_agg = btree::make_aggregate<timestamp, 2, btree::classic>(f, identity);
   auto bknuckle_agg = btree::make_aggregate<timestamp, 2, btree::knuckle>(f, identity);
   auto bfinger_agg = btree::make_aggregate<timestamp, 2, btree::finger>(f, identity);
-  
+
   while (rep-- > 0) {
     for (uint64_t i=0;i<window_size;i++) {
       recalc_agg.insert(i);
@@ -231,7 +242,8 @@ void test_alg_no_inverse_sawtooth(F f, typename F::Partial identity,
       aba_agg.insert(i);
       twostacks_agg.insert(i);
       twostacks_lite_agg.insert(i);
-      implicit_twostacks_lite_agg.insert(i);
+      rb_twostacks_lite_agg.insert(i);
+      chunked_twostacks_lite_agg.insert(i);
       flatfit_agg.insert(i);
       dyn_flatfit_agg.insert(i);
       reactive_agg.insert(i);
@@ -245,7 +257,8 @@ void test_alg_no_inverse_sawtooth(F f, typename F::Partial identity,
       real_assert(res == aba_agg.query(), name + ": recalc != aba");
       real_assert(res == twostacks_agg.query(), name + ": recalc != two_stacks");
       real_assert(res == twostacks_lite_agg.query(), name + ": recalc != two_stacks_lite");
-      real_assert(res == implicit_twostacks_lite_agg.query(), name + ": recalc != implicit_two_stacks_lite");      
+      real_assert(res == rb_twostacks_lite_agg.query(), name + ": recalc != rb_two_stacks_lite");
+      real_assert(res == chunked_twostacks_lite_agg.query(), name + ": recalc != chunked_two_stacks_lite");
       real_assert(res == flatfit_agg.query(), name + ": recalc != flatfit");
       real_assert(res == dyn_flatfit_agg.query(), name + ": recalc != dyn_flatfit");
       real_assert(res == reactive_agg.query(), name + ": recalc != reactive");
@@ -260,7 +273,8 @@ void test_alg_no_inverse_sawtooth(F f, typename F::Partial identity,
       aba_agg.evict();
       twostacks_agg.evict();
       twostacks_lite_agg.evict();
-      implicit_twostacks_lite_agg.evict();      
+      rb_twostacks_lite_agg.evict();
+      chunked_twostacks_lite_agg.evict();
       flatfit_agg.evict();
       dyn_flatfit_agg.evict();
       recalc_agg.evict();
@@ -275,7 +289,8 @@ void test_alg_no_inverse_sawtooth(F f, typename F::Partial identity,
       real_assert(res == aba_agg.query(), name + ": recalc != aba");
       real_assert(res == twostacks_agg.query(), name + ": recalc != two_stacks");
       real_assert(res == twostacks_lite_agg.query(), name + ": recalc != two_stacks_lite");
-      real_assert(res == implicit_twostacks_lite_agg.query(), name + ": recalc != implicit_two_stacks_lite");      
+      real_assert(res == rb_twostacks_lite_agg.query(), name + ": recalc != rb_two_stacks_lite");
+      real_assert(res == chunked_twostacks_lite_agg.query(), name + ": recalc != chunked_two_stacks_lite");
       real_assert(res == flatfit_agg.query(), name + ": recalc != flatfit");
       real_assert(res == dyn_flatfit_agg.query(), name + ": recalc != dyn_flatfit");
       real_assert(res == reactive_agg.query(), name + ": recalc != reactive");
@@ -299,7 +314,8 @@ void test_alg_no_inverse_thirds(F f, typename F::Partial identity,
   auto aba_agg = aba::make_aggregate(f, identity);
   auto twostacks_agg = twostacks::make_aggregate(f, identity);
   auto twostacks_lite_agg = twostackslite::make_aggregate(f, identity);
-  auto implicit_twostacks_lite_agg = implicit_twostackslite::make_aggregate(f, identity);
+  auto rb_twostacks_lite_agg = rb_twostackslite::make_aggregate(f, identity);
+  auto chunked_twostacks_lite_agg = chunked_twostackslite::make_aggregate(f, identity);
   auto flatfit_agg = flatfit::make_aggregate(f, identity);
   auto dyn_flatfit_agg = dynamic_flatfit::make_aggregate(f, identity);
   auto recalc_agg = recalc::make_aggregate(f, identity);
@@ -320,7 +336,8 @@ void test_alg_no_inverse_thirds(F f, typename F::Partial identity,
       aba_agg.insert(epoch_no);
       twostacks_agg.insert(epoch_no);
       twostacks_lite_agg.insert(epoch_no);
-      implicit_twostacks_lite_agg.insert(epoch_no);
+      rb_twostacks_lite_agg.insert(epoch_no);
+      chunked_twostacks_lite_agg.insert(epoch_no);
       flatfit_agg.insert(epoch_no);
       dyn_flatfit_agg.insert(epoch_no);
       reactive_agg.insert(epoch_no);
@@ -334,7 +351,8 @@ void test_alg_no_inverse_thirds(F f, typename F::Partial identity,
       real_assert(res == aba_agg.query(), name + ": recalc != aba");
       real_assert(res == twostacks_agg.query(), name + ": recalc != two_stacks");
       real_assert(res == twostacks_lite_agg.query(), name + ": recalc != two_stacks_lite");
-      real_assert(res == implicit_twostacks_lite_agg.query(), name + ": recalc != implicit_two_stacks_lite");      
+      real_assert(res == rb_twostacks_lite_agg.query(), name + ": recalc != rb_two_stacks_lite");
+      real_assert(res == chunked_twostacks_lite_agg.query(), name + ": recalc != chunked_two_stacks_lite");
       real_assert(res == flatfit_agg.query(), name + ": recalc != flatfit");
       real_assert(res == dyn_flatfit_agg.query(), name + ": recalc != dyn_flatfit");
       real_assert(res == reactive_agg.query(), name + ": recalc != reactive");
@@ -349,7 +367,8 @@ void test_alg_no_inverse_thirds(F f, typename F::Partial identity,
       aba_agg.evict();
       twostacks_agg.evict();
       twostacks_lite_agg.evict();
-      implicit_twostacks_lite_agg.evict();      
+      rb_twostacks_lite_agg.evict();
+      chunked_twostacks_lite_agg.evict();
       flatfit_agg.evict();
       dyn_flatfit_agg.evict();
       recalc_agg.evict();
@@ -364,7 +383,8 @@ void test_alg_no_inverse_thirds(F f, typename F::Partial identity,
       real_assert(res == aba_agg.query(), name + ": recalc != aba");
       real_assert(res == twostacks_agg.query(), name + ": recalc != two_stacks");
       real_assert(res == twostacks_lite_agg.query(), name + ": recalc != two_stacks_lite");
-      real_assert(res == implicit_twostacks_lite_agg.query(), name + ": recalc != implicit_two_stacks_lite");      
+      real_assert(res == rb_twostacks_lite_agg.query(), name + ": recalc != rb_two_stacks_lite");
+      real_assert(res == chunked_twostacks_lite_agg.query(), name + ": recalc != chunked_two_stacks_lite");
       real_assert(res == flatfit_agg.query(), name + ": recalc != flatfit");
       real_assert(res == dyn_flatfit_agg.query(), name + ": recalc != dyn_flatfit");
       real_assert(res == reactive_agg.query(), name + ": recalc != reactive");
@@ -612,7 +632,7 @@ void test_timestamped_fifo(F f, typename F::Partial identity, uint64_t iteration
             daba_lite_agg.evict();
             twostacks_agg.evict();
             twostacks_lite_agg.evict();
-            implicit_twostacks_lite_agg.evict();            
+            implicit_twostacks_lite_agg.evict();
             flatfit_agg.evict();
             recalc_agg.evict();
             bclassic_agg.evict();
@@ -624,10 +644,10 @@ void test_timestamped_fifo(F f, typename F::Partial identity, uint64_t iteration
         daba_lite_agg.insert(i, i);
         twostacks_agg.insert(i, i);
         twostacks_lite_agg.insert(i, i);
-        implicit_twostacks_lite_agg.insert(i, i);        
+        implicit_twostacks_lite_agg.insert(i, i);
         flatfit_agg.insert(i, i);
         bclassic_agg.insert(i, i);
-        bfinger_agg.insert(i, i);        
+        bfinger_agg.insert(i, i);
 
         typename F::Out res = recalc_agg.query();
         real_assert(res == daba_agg.query(), name + ": recalc != daba");


### PR DESCRIPTION
* Further optimized the ring-buffer-based implementation. An iterator now keeps a pointer pointing directly to the data location, removing one level of indirection.
* Refactored the two-stacks implementation, so the aggregators using a ring buffer and a chunked-array queue are the same code.
* Updated the timestamped counterpart
* Propagating the changes to the benchmark drivers (rb_twostacks_lite and timestamped_rb_twostacks_lite for ring-buffer-based, and chunked_ for chunked-array-based)
* 