### PR TITLE
Rust implementation of Two-Stacks Lite

### DIFF
--- a/rust/benches/bench_static.rs
+++ b/rust/benches/bench_static.rs
@@ -12,6 +12,7 @@ use swag::reactive::Reactive;
 use swag::recalc::ReCalc;
 use swag::soe::SoE;
 use swag::two_stacks::TwoStacks;
+use swag::two_stacks_lite::TwoStacksLite;
 use swag::ops::AggregateOperator;
 use swag::ops::max::Max;
 use swag::ops::mean::Mean;
@@ -94,10 +95,11 @@ fn main() {
                                                       opts.latency);
     query_run! {
         opts, i32 =>
-            [[ReCalc,    Max, Mean, Sum],
-             [TwoStacks, Max, Mean, Sum],
-             [Reactive,  Max, Mean, Sum],
-             [SoE,            Mean, Sum]]
+            [[ReCalc,        Max, Mean, Sum],
+             [TwoStacks,     Max, Mean, Sum],
+             [TwoStacksLite, Max, Mean, Sum],
+             [Reactive,      Max, Mean, Sum],
+             [SoE,           Mean, Sum]]
     }
 
     // Should not reach here

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -57,6 +57,9 @@ pub mod soe;
 /// Two-Stacks
 pub mod two_stacks;
 
+/// Two-Stacks Lite
+pub mod two_stacks_lite;
+
 /// Reactive-Aggregator
 pub mod reactive;
 

--- a/rust/src/two_stacks_lite/mod.rs
+++ b/rust/src/two_stacks_lite/mod.rs
@@ -1,0 +1,82 @@
+use std::collections::VecDeque;
+
+use alga::general::AbstractMagma;
+use alga::general::Identity;
+
+use crate::FifoWindow;
+use crate::ops::AggregateOperator;
+use crate::ops::AggregateMonoid;
+
+#[derive(Clone)]
+pub struct TwoStacksLite<BinOp>
+where
+    BinOp: AggregateMonoid<BinOp> + AggregateOperator + Clone
+{
+    queue: VecDeque<BinOp::Partial>,
+    agg_back: BinOp::Partial,
+    front_len: usize,
+}
+
+impl<BinOp> FifoWindow<BinOp> for TwoStacksLite<BinOp>
+where
+    BinOp: AggregateMonoid<BinOp> + AggregateOperator + Clone
+{
+    fn new() -> Self {
+        Self {
+            queue: VecDeque::new(),
+            agg_back: BinOp::Partial::identity(),
+            front_len: 0,
+        }
+    }
+    fn name() -> &'static str {
+        "two_stacks_lite"
+    }
+    fn push(&mut self, v: BinOp::In) {
+        let lifted = BinOp::lift(v);
+        self.queue.push_back(lifted.clone());
+        self.agg_back = self.agg_back.operate(&lifted);
+    }
+    fn pop(&mut self) -> Option<BinOp::Out> {
+        if self.queue.is_empty() {
+            None
+        } else {
+            let end = self.queue.len() - 1;
+            if self.front_len == 0 {
+                let mut i = end;
+                while i != 0 {
+                   i -= 1;
+                   self.queue[i] = self.queue[i].operate(&self.queue[i+1]);
+                }
+                self.front_len = end + 1;
+                self.agg_back = BinOp::Partial::identity();
+            }
+            self.front_len -= 1;
+            self.queue.pop_front().map(|item| BinOp::lower(&item))
+        }
+    }
+    fn query(&self) -> BinOp::Out {
+        let f = &self.agg_front();
+        let b = &self.agg_back;
+        BinOp::lower(&f.operate(&b))
+    }
+    fn len(&self) -> usize {
+        self.queue.len()
+    }
+    fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+}
+
+impl<BinOp> TwoStacksLite<BinOp>
+where
+    BinOp: AggregateMonoid<BinOp> + AggregateOperator + Clone
+{
+    #[inline(always)]
+    fn agg_front(&self) -> BinOp::Partial {
+        if self.front_len == 0 || self.queue.is_empty() {
+            BinOp::Partial::identity()
+        } else {
+            self.queue.front().unwrap().clone()
+        }
+    }
+}

--- a/rust/tests/fifo_window.rs
+++ b/rust/tests/fifo_window.rs
@@ -4,6 +4,7 @@ use swag::recalc;
 use swag::soe;
 use swag::reactive;
 use swag::two_stacks;
+use swag::two_stacks_lite;
 use swag::flatfit;
 use swag::FifoWindow;
 use swag::ops::max::Max;
@@ -234,18 +235,18 @@ where
 }
 
 test_matrix! {
-    test1 =>     [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, flatfit::FlatFIT ],
-    test2 =>     [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, flatfit::FlatFIT ],
-    test3 =>     [ recalc::ReCalc,           reactive::Reactive, two_stacks::TwoStacks, flatfit::FlatFIT ],
-    test4 =>     [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, flatfit::FlatFIT ],
-    test5 =>     [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, flatfit::FlatFIT ],
-    test6 =>     [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, flatfit::FlatFIT ],
-    test7 =>     [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, flatfit::FlatFIT ],
-    test8 =>     [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, flatfit::FlatFIT ],
-    test9 =>     [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, flatfit::FlatFIT ],
-    test_max =>  [ recalc::ReCalc,           reactive::Reactive, two_stacks::TwoStacks, flatfit::FlatFIT ],
-    test_sum =>  [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, flatfit::FlatFIT ],
-    test_mean => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, flatfit::FlatFIT ]
+    test1 =>     [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, two_stacks_lite::TwoStacksLite, flatfit::FlatFIT ],
+    test2 =>     [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, two_stacks_lite::TwoStacksLite, flatfit::FlatFIT ],
+    test3 =>     [ recalc::ReCalc,           reactive::Reactive, two_stacks::TwoStacks, two_stacks_lite::TwoStacksLite, flatfit::FlatFIT ],
+    test4 =>     [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, two_stacks_lite::TwoStacksLite, flatfit::FlatFIT ],
+    test5 =>     [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, two_stacks_lite::TwoStacksLite, flatfit::FlatFIT ],
+    test6 =>     [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, two_stacks_lite::TwoStacksLite, flatfit::FlatFIT ],
+    test7 =>     [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, two_stacks_lite::TwoStacksLite, flatfit::FlatFIT ],
+    test8 =>     [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, two_stacks_lite::TwoStacksLite, flatfit::FlatFIT ],
+    test9 =>     [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, two_stacks_lite::TwoStacksLite, flatfit::FlatFIT ],
+    test_max =>  [ recalc::ReCalc,           reactive::Reactive, two_stacks::TwoStacks, two_stacks_lite::TwoStacksLite, flatfit::FlatFIT ],
+    test_sum =>  [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, two_stacks_lite::TwoStacksLite, flatfit::FlatFIT ],
+    test_mean => [ recalc::ReCalc, soe::SoE, reactive::Reactive, two_stacks::TwoStacks, two_stacks_lite::TwoStacksLite, flatfit::FlatFIT ]
 }
 
 #[test]
@@ -254,6 +255,7 @@ fn assert_names() {
     assert_eq!(flatfit::FlatFIT::<Sum::<i32, i32>>::name(), "flatfit");
     assert_eq!(reactive::Reactive::<Sum::<i32, i32>>::name(), "reactive");
     assert_eq!(two_stacks::TwoStacks::<Sum::<i32, i32>>::name(), "two_stacks");
+    assert_eq!(two_stacks_lite::TwoStacksLite::<Sum::<i32, i32>>::name(), "two_stacks_lite");
     assert_eq!(soe::SoE::<Sum::<i32, i32>>::name(), "soe");
 }
 


### PR DESCRIPTION
This PR implements Two-Stacks Lite in Rust, as explained in Section 4 of [In-Order Sliding-Window Aggregation in Worst-Case Constant Time](https://arxiv.org/abs/2009.13768).

However, this implementation is a little different from that paper. In there, Two-Stacks Lite requires a `queue` of partials, a pointer `F` to the front of `queue` which is also the "front stack," a pointer `E` which is to the back of `queue`, and a pointer `B` which is between `F` and `E` and is the start of the "back stack."

My implementation uses a `std::collections::VecDeque` as the `queue`. That already buys us implicit `F` and `E` pointers, as `queue.front()` is always the front and `queue.back()` is always the back. What remains is knowing where the "front stack" stops and where the "back stack" starts. Trying to use an actual iterator felt clumsy to do this (and I wasn't sure if it was actually possible).

What I realized is that in Two-Stacks Lite, `B` is never actually used as a pointer to a value. That is, we never use it to reference a value - that's what `aggB` is for. Its use is to know when `F` is empty and we need to flip. But we should be able to accomplish that with a counter for the size of the front stack which we decrement on a pop.

The fields I ended up with are:

```rust
pub struct TwoStacksLite<BinOp>
where
    BinOp: AggregateMonoid<BinOp> + AggregateOperator + Clone
{
    queue: VecDeque<BinOp::Partial>,
    agg_back: BinOp::Partial,
    front_len: usize,
}
```

With all that said, I don't have a correction proof, so I may have missed something.