### PR TITLE
Bulk eviction

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -27,6 +27,9 @@ test: bin/test
 bin/test: log src/test.cc $(SWAG_ALGOS)
 	$(CXX) -std=gnu++17 -DHAS_UNCAUGHT_EXCEPTIONS=1 -ggdb src/test.cc -o bin/test
 
+bin/bulk_evict_test: log src/bulk_evict_test.cc $(SWAG_ALGOS)
+	$(CXX) -std=gnu++17 -DHAS_UNCAUGHT_EXCEPTIONS=1 -ggdb src/bulk_evict_test.cc -o bin/bulk_evict_test
+
 benchmark_driver: log src/benchmark_driver.cc src/benchmark_core.h $(SWAG_ALGOS)
 	$(CXX) $(CXXFLAGS) src/benchmark_driver.cc -o bin/benchmark_driver
 

--- a/cpp/src/FiBA.hpp
+++ b/cpp/src/FiBA.hpp
@@ -5,7 +5,7 @@
 #include <cassert>
 #include <cmath>
 #include <limits>
-#include <vector>
+#include <deque>
 
 #include "utils.h"
 
@@ -574,7 +574,7 @@ private:
   Node *_root;
   Node *_leftFinger, *_rightFinger;
   size_t _size;
-  vector<Node*> _freeList;
+  deque<Node*> _freeList;
 
   void deleteNode(Node* node, bool recursive) {
     if (recursive && !node->isLeaf())
@@ -899,7 +899,7 @@ private:
     { }
   };
 
-  typedef vector<BoundaryLevel> BoundaryT;
+  typedef deque<BoundaryLevel> BoundaryT;
 
   void searchBoundary(timeT time, BoundaryT& result) const {
     Node* node = _root;

--- a/cpp/src/FiBA.hpp
+++ b/cpp/src/FiBA.hpp
@@ -1242,6 +1242,10 @@ public:
     if (top->isRoot()) {
       hitLeft = true;
       hitRight = true;
+      if (top->arity() == 1 && !top->isLeaf()) {
+	top = top->getChild(0);
+	heightDecrease();
+      }
     } else if (top->arity() >= minArity) {
       hitLeft = top->leftSpine();
       hitRight = top->rightSpine();

--- a/cpp/src/bulk_evict_test.cc
+++ b/cpp/src/bulk_evict_test.cc
@@ -1,0 +1,27 @@
+#include "FiBA.hpp"
+#include "AggregationFunctions.hpp"
+
+int main() {
+  for (int i=0, n=1000; i<n; i++) {
+    auto tree = btree::Aggregate<int, 2, btree::finger, Collect<int>>::makeRandomTree(Collect<int>(), 4);
+    int maxTime = tree->youngest();
+    int minTime = rand() % maxTime;
+    std::cout << "iteration " << i << ", minTime " << minTime << ", maxTime " << maxTime << std::endl;
+    tree->evictUpTo(minTime);
+    auto collected = tree->query();
+    int pred = minTime;
+    for (auto j=collected.begin(); j!=collected.end(); j++) {
+      if (pred + 1 != *j) {
+	for (auto k=collected.begin(); k!=collected.end(); k++)
+	  std::cout << *k << " ";
+	std::cout << *tree;
+	assert(false);
+      }
+      pred = *j;
+    }
+    assert(pred == maxTime);
+    delete tree;
+  }
+  std::cout << "bulk_evict_test passed" << std::endl;
+  return 0;
+}

--- a/cpp/src/bulk_evict_test.cc
+++ b/cpp/src/bulk_evict_test.cc
@@ -1,27 +1,46 @@
 #include "FiBA.hpp"
 #include "AggregationFunctions.hpp"
 
-int main() {
-  for (int i=0, n=1000; i<n; i++) {
-    auto tree = btree::Aggregate<int, 2, btree::finger, Collect<int>>::makeRandomTree(Collect<int>(), 4);
-    int maxTime = tree->youngest();
-    int minTime = rand() % maxTime;
-    std::cout << "iteration " << i << ", minTime " << minTime << ", maxTime " << maxTime << std::endl;
-    tree->evictUpTo(minTime);
-    auto collected = tree->query();
-    int pred = minTime;
-    for (auto j=collected.begin(); j!=collected.end(); j++) {
-      if (pred + 1 != *j) {
+template<int minArity>
+void test_one(int height, int iteration, bool verbose) {
+  typedef btree::Aggregate<int, minArity, btree::finger, Collect<int>> Tree;
+  auto tree = Tree::makeRandomTree(Collect<int>(), height);
+  int maxTime = tree->youngest();
+  int minTime = rand() % maxTime;
+  if (verbose) std::cout << "iteration " << iteration << ", minTime " << minTime << ", maxTime " << maxTime << std::endl;
+  if (verbose) std::cout << *tree;
+  tree->evictUpTo(minTime);
+  auto collected = tree->query();
+  int pred = minTime;
+  for (auto j=collected.begin(); j!=collected.end(); j++) {
+    if (pred + 1 != *j) {
+	std::cerr << "iteration " << iteration << " collected items and tree ";
 	for (auto k=collected.begin(); k!=collected.end(); k++)
-	  std::cout << *k << " ";
-	std::cout << *tree;
+	  std::cerr << *k << " ";
+	std::cerr << std::endl << *tree;
 	assert(false);
-      }
-      pred = *j;
     }
-    assert(pred == maxTime);
-    delete tree;
+    pred = *j;
   }
+  assert(pred == maxTime);
+  delete tree;
+}
+
+int main() {
+  for (int i=0, n=100; i<n; i++)
+    test_one<2>(3, i, false);
+  for (int i=0, n=1000; i<n; i++)
+    test_one<2>(4, i, false);
+  for (int i=0, n=100; i<n; i++)
+    test_one<3>(4, i, false);
+  for (int i=0, n=100; i<n; i++)
+    test_one<4>(4, i, false);
+  for (int i=0, n=500; i<n; i++)
+    test_one<2>(5, i, false);
+  for (int i=0, n=250; i<n; i++)
+    test_one<2>(6, i, false);
+  for (int i=0, n=100; i<n; i++)
+    test_one<2>(7, i, false);
   std::cout << "bulk_evict_test passed" << std::endl;
   return 0;
 }


### PR DESCRIPTION
Defines method evictUpTo for FiBA, which efficiently evicts data items from the oldest end of the window in bulk. This PR goes to a new branch of the base repository so we can jointly develop it more before merging to master. One thing that is still to be added is a deferred free list to prevent latency spikes from recursive bulk deallocation.