### PR TITLE
Move query in bulk evict out of insert loop; add barrier

### DIFF
--- a/cpp/src/benchmark_core.h
+++ b/cpp/src/benchmark_core.h
@@ -297,9 +297,10 @@ void bulk_evict_benchmark(Aggregate agg, Experiment exp) {
 
             agg.bulkEvict(i - exp.window_size + exp.bulk_size - 1);
             for (typename Aggregate::timeT j = 0; j < exp.bulk_size && i < stop_pos; ++j, ++i) {
+                std::atomic_thread_fence(std::memory_order_seq_cst);
                 agg.insert(i, 1 + (i % 101));
-                silly_combine(force_side_effect, agg.query());
             }
+            silly_combine(force_side_effect, agg.query());
         }
 
         std::chrono::duration<double> runtime = std::chrono::system_clock::now() - start;


### PR DESCRIPTION
Moves the query call in the bulk evict benchmark out of the insert loop. We decided this allowed us to isolate the bulk evict more, which is what we're more interested in measuring.

Also, this adds a barrier to the inside of the insert loop. I did that for the same reason we have it in general: to avoid loop-unrolling style optimizations, and enforce a tuple-at-a-time simulation.