### PR TITLE
An adapter to simulate bulk operations using multiple singleton operations

### DIFF
--- a/cpp/src/BulkAdapter.hpp
+++ b/cpp/src/BulkAdapter.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+template <class Base, typename timeT, typename inT>
+class BulkAdapter : public Base {
+
+  void bulkInsert(vector<pair<timeT, inT>> entries) {
+    bulkInsert(entries.begin(), entries.end());
+  }
+
+  template <class Iterator>
+  void bulkInsert(Iterator begin, Iterator end) {
+      for (auto it=begin;it!=end;it++) {
+          Base::insert(it->first, it->second);
+      }
+  }
+
+  void bulkEvict(timeT const& time) {
+      while (Base::oldest() <= time) {
+          Base::evict();
+      }
+  }
+};

--- a/cpp/src/BulkAdapter.hpp
+++ b/cpp/src/BulkAdapter.hpp
@@ -1,9 +1,12 @@
 #pragma once
+#include<vector>
+#include<utility>
 
 template <class Base, typename timeT, typename inT>
 class BulkAdapter : public Base {
+  using Base::Base;
 
-  void bulkInsert(vector<pair<timeT, inT>> entries) {
+  void bulkInsert(std::vector<std::pair<timeT, inT>> entries) {
     bulkInsert(entries.begin(), entries.end());
   }
 


### PR DESCRIPTION
@hirzel Does `bulkEvict(t)` evict the record at timestamp exactly `t` as well?