### PR TITLE
Implement Amortized MTA with bulkEvict

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ provide more background on sliding window aggregation algorithms.
 - **first appeared**: no known source
 - **implementations**: [C++](cpp/src/SubtractOnEvict.hpp) (strictly in-order),
                       [Rust](rust/src/soe/mod.rs) (strictly in-order)
+                      
+# Amortized MTA (AMTA)
+- **full name**: Amortized Monoid Tree Aggregator
+- **ordering**: in-order required
+- **operator requirements**: associativity
+- **time complexity**: 
+    -  worst-case O(log *n*), amortized O(1) for `insert` and `evict`;
+    -  worst-case O(1) for `query`; and 
+    -  worst-case O(log *n*) for `bulkEvict`
+- **space requirements**: O(*n*)
+- **first appeared**: [Constant-Time Sliding Window Framework with Reduced Memory Footprint and Efficient Bulk Evictions][tpds2018]
+- **implementions**: [C++](cpp/src/AMTA.hpp)
 
 [swag_tutorial]: https://dl.acm.org/doi/abs/10.1145/3093742.3095107
 [swag_encyclopedia]: http://hirzels.com/martin/papers/encyc18-sliding-window.pdf
@@ -122,3 +134,4 @@ provide more background on sliding window aggregation algorithms.
 [vldb2019]: http://www.vldb.org/pvldb/vol12/p1167-tangwongsan.pdf
 [vldb2015]: http://www.vldb.org/pvldb/vol8/p702-tangwongsan.pdf
 [vldbj2021]: https://doi.org/10.1007/s00778-021-00668-3
+[tpds2018]: https://doi.org/10.1109/TPDS.2018.2868960

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -4,7 +4,8 @@ SWAG_ALGOS=src/ChunkedArrayQueue.hpp \
            src/ImplicitQueueABA.hpp src/DABA.hpp src/DABALite.hpp \
 		   src/SubtractOnEvict.hpp \
            src/OkasakisQueue.hpp src/FiBA.hpp \
-           src/TimestampedFifo.hpp
+           src/TimestampedFifo.hpp \
+		   src/AMTA.hpp
 
 all: benchmark_driver \
 	 benchmark_driver_stats \
@@ -39,6 +40,9 @@ bin/test: log src/test.cc $(SWAG_ALGOS)
 
 bin/bulk_test: log src/bulk_test.cc $(SWAG_ALGOS)
 	$(CXX) -std=gnu++17 -DHAS_UNCAUGHT_EXCEPTIONS=1 -ggdb src/bulk_test.cc -o $@
+
+bin/amta_test: src/amta_test.cc $(SWAG_ALGOS)
+	$(CXX) -std=gnu++17 -ggdb -DHAS_UNCAUGHT_EXCEPTIONS=1 -ggdb src/amta_test.cc -o $@
 
 benchmark_driver: log src/benchmark_driver.cc src/benchmark_core.h $(SWAG_ALGOS)
 	$(CXX) $(CXXFLAGS) src/benchmark_driver.cc -o bin/benchmark_driver

--- a/cpp/src/AMTA.hpp
+++ b/cpp/src/AMTA.hpp
@@ -1,0 +1,382 @@
+#pragma once
+
+#include <cassert>
+#include <deque>
+#include <iostream>
+#include <ostream>
+#include <vector>
+#include <iterator>
+
+/* This file contains an implementation of our interpretation of the Amortized
+ * MTA data structure from the following paper:
+ *
+ *   Álvaro Villalba, Josep Lluís Berral, and David Carrera
+ *
+ *   Constant-Time Sliding Window Framework with Reduced Memory Footprint and
+ *   Efficient Bulk Evictions
+ *
+ *   IEEE Transactions on Parallel and Distributed Systems
+ *   (Volume: 30, Issue: 3, March 1 2019)
+ *
+ *   https://doi.org/10.1109/TPDS.2018.2868960
+ * */
+namespace amta {
+
+using namespace std;
+
+constexpr bool PRINT_DEBUG = false;
+template <typename _timeT, typename binOpFunc>
+class Aggregate {
+public:
+  typedef typename binOpFunc::In inT;
+  typedef typename binOpFunc::Partial aggT;
+  typedef typename binOpFunc::Out outT;
+  typedef _timeT timeT;
+
+private:
+  /* Node is an internal binary-tree node structure and as such, a node
+   * can have at most two children.
+   *
+   *     o The "arity" field can be 0, 1, 2, -1, indicating how many children it
+   *     has, where -1 means one child on the right (left has been popped).
+   *
+   *     o For i = 0, 1, agg[i] stores the aggregated value of the subtree
+   *     pointed to by children[i]--and times[i] is the largest timestamp in
+   *     that subtree.
+   * */
+  struct Node {
+    aggT agg[2];
+    timeT times[2];
+    Node* children[2];
+    Node* parent;
+    int arity;
+    Node(aggT a, timeT t, Node* left) { init(a, t, left); }
+    void init(aggT a, timeT t, Node *left) {
+      parent = NULL, arity = 0;
+      push_back(a, t, left);
+    }
+    void push_back(aggT a, timeT t, Node *child) {
+      assert (arity == 0 || arity == 1);
+      agg[arity] = a; times[arity] = t; children[arity] = child; arity++;
+      if (child != NULL) child->parent = this;
+    }
+    Node* pop_front() {
+      assert(arity != 0);
+      if (abs(arity) == 1) {
+        arity = 0;
+        return this->children[1];
+      } else {
+        arity = -1;
+        return this->children[0];
+      }
+    }
+    bool leftPopped() { return arity == -1; }
+    bool rightEmpty() { return arity == 1; }
+    bool full() { return arity == 2; }
+    bool isLeaf() { return arity == 0; }
+
+    ostream& printNode(ostream& os) const {
+      os << "[";
+      for (int i = 0; i < arity; i++)
+        os << this->times[i] << "/" << this->agg[i] << ",";
+      if (arity == -1)
+        os << "-, " << this->times[1] << "/"  << this->agg[1];
+      os << "]";
+      return os;
+    }
+  };
+
+  friend inline std::ostream& operator<<(std::ostream& os, Node const& x) {
+    return x.printNode(os);
+  }
+
+  binOpFunc _binOp;
+  size_t _size;
+  vector<Node *> _tails;
+  Node* _frontNode; // ptr to the node storing the oldest elt
+  deque<aggT> _frontStack;
+  aggT _identE, _frontSum, _backSum;
+  vector<Node *> _freeList;
+
+public:
+  Aggregate(binOpFunc binOp, aggT identE_)
+      : _binOp(binOp), _size(0), _tails(), _frontNode(NULL),
+        _frontStack(), _identE(identE_), _frontSum(identE_), _backSum(identE_) {
+  }
+
+  ~Aggregate() {
+    while (!_freeList.empty())
+      _compactFreeList();
+  }
+
+  void print() {
+    std::cout << "_tails:";
+    for (int i = _tails.size() - 1; i >= 0; i--) {
+      std::cout << " " << *(_tails[i]);
+    }
+    std::cout << std::endl;
+    std::cout << "_frontSum=" << _frontSum << ", _backSum=" << _backSum
+              << std::endl;
+    std::cout << "_frontStack:";
+    for (auto elt: _frontStack) { std::cout << elt << ", "; }
+    std::cout << std::endl;
+    std::cout << "_frontNode:" << *_frontNode << std::endl;
+  }
+  void rebuildFrontFrom(Node *c) {
+    aggT agg = _frontStack.empty()?_identE:_frontStack.back();
+    while (c != NULL) {
+      Node *next = c->leftPopped() ? c->children[1] : c->children[0];
+      if (c->full()) {
+        agg = _binOp.combine(c->agg[1], agg);
+        _frontStack.push_back(agg);
+      }
+      if (next == NULL) // reset the frontNode pointer
+        _frontNode = c;
+      c = next;
+    }
+  }
+  void rebuildFront() {
+    if (_tails.empty()) { _frontSum = _identE; return ;}
+    _frontStack.clear();
+
+    rebuildFrontFrom(_tails.back());
+    aggT agg = _frontStack.empty() ? _identE : _frontStack.back();
+    aggT other = (_frontNode->full() || _frontNode->rightEmpty())
+                     ? _frontNode->agg[0]
+                     : _frontNode->agg[1];
+    _frontSum = _binOp.combine(other, agg);
+  }
+
+  void rebuildBack() {
+    if (_tails.empty()) { _backSum = _identE; return ;}
+    aggT agg = _identE;
+    auto it = _tails.rbegin();
+
+    while (++it != _tails.rend()) {
+      Node *c = *it;
+      aggT nodeAgg =
+          c->full() ? _binOp.combine(c->agg[0], c->agg[1]) : c->agg[0];
+      agg = _binOp.combine(agg, nodeAgg);
+    }
+    _backSum = agg;
+  }
+
+  void evict() {
+    _frontSum = _frontStack.empty() ? _identE : _frontStack.back();
+    if (_size > 0) _size--;
+    Node *c = _frontNode;
+    while (c != NULL) {
+      if (c->full()) _frontStack.pop_back(); // was a full node, no longer
+      c->pop_front();
+      if (c->arity != 0)
+        break;
+      Node *next = c->parent;
+      _deleteNode(c);
+      c = next;
+    }
+    if (c == NULL) { // hit the big root
+      if (PRINT_DEBUG) std::cout << "big root emptied, moving on..." << std::endl;
+      _tails.pop_back();
+      _frontNode = NULL;
+      rebuildFront(), rebuildBack();
+    }
+    else
+      rebuildFrontFrom(c);
+  }
+
+  void _slice(Node *node, timeT const& time) {
+    while (node != NULL) {
+      if (!node->leftPopped()) {
+        if (time < node->times[0]) {
+          node = node->children[0];
+          continue;
+        }
+        else if (time == node->times[0]) {
+          _deleteNode(node->pop_front());
+          break;
+        }
+      }
+      if (!node->rightEmpty() && time < node->times[1]) {
+          _deleteNode(node->pop_front());
+          node = node->children[1];
+          continue;
+      }
+      // should never reach this case
+      throw 1;
+    }
+  }
+
+  void _emptyOutNode(Node *node) {
+    if (node != NULL && !node->isLeaf()) {
+      if (!node->leftPopped())
+        _freeList.push_back(node->children[0]);
+      if (!node->rightEmpty())
+        _freeList.push_back(node->children[1]);
+    }
+  }
+
+  Node* _newNode(aggT a, timeT t, Node* left) {
+    if (_freeList.empty())
+      return new Node(a, t, left);
+    Node* node = _freeList.back();
+    _freeList.pop_back();
+    _emptyOutNode(node);
+    node->init(a, t, left);
+    return node;
+  }
+
+  void _deleteNode(Node* node, bool recursive=true) {
+    if (node == NULL)
+      return ; // nothing to delete
+    if (recursive) _emptyOutNode(node);
+    delete node;
+  }
+
+  void _compactFreeList() {
+    Node* node = _freeList.back();
+    _freeList.pop_back();
+    _emptyOutNode(node);
+    delete node;
+  }
+
+  void bulkEvict(timeT const& time) {
+    if (_tails.empty() || time < oldest()) return ; // nothing to evict
+
+    _size = -1; // size tracking will stop working from this point on
+    while (!_tails.empty()) {
+      Node *head = _tails.back();
+      timeT mostRecent = head->rightEmpty() ? head->times[0] : head->times[1];
+      if (PRINT_DEBUG) std::cout << "considering --" << *head << std::endl;
+      if (PRINT_DEBUG) std::cout << "mostRecent=" << mostRecent << std::endl;
+      if (time < mostRecent) {
+        if (PRINT_DEBUG) std::cout << "Slicing the head node" << std::endl;
+        // stop at this root, but slice it before we quit
+        if (head->full()) {
+          if (PRINT_DEBUG) std::cout << "head is full" << std::endl;
+          if (time >= head->times[0]) {
+            // delete the left subtree completely & slice the right tree
+            if (PRINT_DEBUG) std::cout << "== delete left; slice right" << std::endl;
+            _deleteNode(head->pop_front());
+            _slice(head->children[1], time);
+          } else {
+            if (PRINT_DEBUG) std::cout << "== slice left" << std::endl;
+             // slice the left subtree but leave the right tree alone
+            _slice(head->children[0], time);
+          }
+        } else {
+          int indicator = head->rightEmpty()?0:1;
+          if (PRINT_DEBUG) {
+            std::cout << "## not full, slicing indictor=" << indicator
+                      << std::endl;
+          }
+          _slice(head->children[indicator], time); // slice the only subtree
+        }
+
+        // done, no more eviction this time
+        break;
+      }
+      if (PRINT_DEBUG) std::cout << "Evicting whole head" << std::endl;
+      // evict this whole root, plus perhaps some more
+      _deleteNode(head); _tails.pop_back();
+
+      // shortcut the case where this head ends with time
+      if (mostRecent == time) break;
+    }
+    rebuildBack(), rebuildFront();
+
+    if (PRINT_DEBUG) this->print();
+  }
+  void bulkInsert(vector<pair<timeT, inT>> entries) {
+    bulkInsert(entries.begin(), entries.end());
+  }
+
+  template <class Iterator>
+  void bulkInsert(Iterator begin, Iterator end) {
+      for(auto it=begin;it!=end;it++) {
+          auto [time, value] = *it;
+          insert(time, value);
+      }
+  }
+
+  timeT oldest() const {
+    return _frontNode->leftPopped() ? _frontNode->times[1]
+                                    : _frontNode->times[0];
+  }
+
+  outT query() const {
+    return _binOp.lower(_binOp.combine(_frontSum, _backSum));
+  }
+
+  size_t size() { return _size; }
+
+  timeT youngest() const {
+    Node *backNode = _tails.front();
+    return (backNode->full() || backNode->leftPopped())
+               ? backNode->times[1]
+               : backNode->times[0];
+  }
+
+  void insert_lifted(timeT const& time, aggT const& liftedValue) {
+    bool hasCarry = true;
+    Node *carriedFrom = NULL;
+    aggT carry = liftedValue;
+    timeT carryTime = time;
+    bool bigRootHit = false;
+    _backSum = _binOp.combine(_backSum, liftedValue);
+    for (auto it = _tails.begin(); it != _tails.end(); it++) {
+      Node *node = *it;
+      if (node->full() || node->leftPopped()) { // has room for carry
+        auto nextCarry = node->full()
+                             ? _binOp.combine(node->agg[0], node->agg[1])
+                             : node->agg[1];
+        auto nextTime = node->times[1];
+        *it = _newNode(carry, carryTime, carriedFrom); // with just carry
+        carriedFrom = node, carry = nextCarry, carryTime = nextTime;
+      } else { // found a non-full node
+        node->push_back(carry, carryTime, carriedFrom);
+        hasCarry = false;
+        if (it + 1 == _tails.end())
+          bigRootHit = true;
+        break;
+      }
+    }
+    if (hasCarry) {
+      Node *n = _newNode(carry, carryTime, carriedFrom);
+      if (_tails.empty())
+        _frontNode = n;
+      _tails.push_back(n);
+    } else if (bigRootHit) {
+      rebuildFront(), rebuildBack();
+    }
+  }
+
+  void insert(timeT const& time, inT const& value) {
+    insert_lifted(time, _binOp.lift(value));
+  }
+
+  void insert(inT const& val) {
+    if (_tails.empty()) {
+      insert(0, val);
+    } else {
+      timeT const time = 1 + youngest();
+      insert(time, val);
+    }
+    if (_size >= 0) _size++;
+  }
+};
+
+template <typename timeT, class BinaryFunction, class T>
+Aggregate<timeT, BinaryFunction>
+make_aggregate(BinaryFunction f, T elem) {
+    return Aggregate<timeT, BinaryFunction>(f, elem);
+}
+
+template <typename BinaryFunction, typename timeT>
+struct MakeAggregate {
+  template <typename T>
+  Aggregate<timeT, BinaryFunction> operator()(T elem) {
+    BinaryFunction f;
+    return make_aggregate<timeT, BinaryFunction>(f, elem);
+  }
+};
+} // namespace amta

--- a/cpp/src/amta_test.cc
+++ b/cpp/src/amta_test.cc
@@ -1,0 +1,65 @@
+#include "AMTA.hpp"
+#include "RingBufferQueue.hpp"
+#include "AggregationFunctions.hpp"
+#include "TimestampedDABALite.hpp"
+
+using namespace std;
+using timestampT = long;
+
+
+void simpleCycles(int n){
+    auto f = Sum<int>();
+    amta::Aggregate agg = amta::make_aggregate<timestampT>(f, 0);
+    auto daba = timestamped_dabalite::make_aggregate<timestampT>(f, 0);
+    for (int i=0;i<n;i++) {
+        agg.insert(i, i+1);
+        daba.insert(i, i+1);
+        agg.print();
+        auto aggQuery = agg.query();
+        cout << aggQuery << endl;
+        assert(aggQuery == daba.query());
+    }
+
+    for (int i=0;i<n-1;i++) {
+        agg.evict();
+        daba.evict();
+        agg.print();
+        auto aggQuery = agg.query();
+        cout << aggQuery << endl;
+        assert(aggQuery == daba.query());
+    }
+    agg.insert(n+1, 7);
+    daba.insert(n+1, 7);
+    agg.print();
+    auto aggQuery = agg.query();
+    cout << aggQuery << endl;
+    assert(aggQuery == daba.query());
+}
+
+void simpleBulkEvict()  {
+    int N = 1499;
+    auto f = Sum<int>();
+    amta::Aggregate agg = amta::make_aggregate<timestampT>(f, 0);
+    auto daba = timestamped_dabalite::make_aggregate<timestampT>(f, 0);
+
+    for (int i=0;i<N;i++) {
+        agg.insert(i, i+1);
+        daba.insert(i, i+1);
+    }
+#define ONE_DANCE(t) {  \
+        agg.bulkEvict(t); \
+        while (daba.size()>0 && daba.oldest() <= t) daba.evict(); \
+        assert(agg.query() == daba.query()); \
+    }  ;
+
+    ONE_DANCE(439);
+    ONE_DANCE(981);
+    ONE_DANCE(1439);
+    ONE_DANCE(1456);
+    ONE_DANCE(1792);
+}
+int main(int argc, char *argv[]) {
+    simpleCycles(17);
+    simpleBulkEvict();
+    return 0;
+}

--- a/cpp/src/test.cc
+++ b/cpp/src/test.cc
@@ -23,6 +23,7 @@
 #include "Reactive.hpp"
 #include "OkasakisQueue.hpp"
 #include "FiBA.hpp"
+#include "AMTA.hpp"
 
 typedef long long int timestamp;
 
@@ -58,6 +59,7 @@ void test_alg_no_inverse(F f, typename F::Partial identity, uint64_t iterations,
     auto bclassic_agg = btree::make_aggregate<timestamp, 2, btree::classic>(f, identity);
     auto bknuckle_agg = btree::make_aggregate<timestamp, 2, btree::knuckle>(f, identity);
     auto bfinger_agg = btree::make_aggregate<timestamp, 2, btree::finger>(f, identity);
+    auto amta_agg = amta::make_aggregate<timestamp>(f, identity);
 
     for (uint64_t i = 0; i < iterations; ++i) {
         size_t sz = recalc_agg.size();
@@ -76,6 +78,7 @@ void test_alg_no_inverse(F f, typename F::Partial identity, uint64_t iterations,
         real_assert(sz == bclassic_agg.size(), name + ": recalc size != bclassic");
         real_assert(sz == bknuckle_agg.size(), name + ": recalc size != bknuckle");
         real_assert(sz == bfinger_agg.size(), name + ": recalc size != bfinger");
+        real_assert(sz == amta_agg.size(), name + ": recalc size != amta");
 
         if (recalc_agg.size() == window_size) {
             daba_agg.evict();
@@ -94,6 +97,7 @@ void test_alg_no_inverse(F f, typename F::Partial identity, uint64_t iterations,
             bclassic_agg.evict();
             bknuckle_agg.evict();
             bfinger_agg.evict();
+            amta_agg.evict();
         }
 
         recalc_agg.insert(i);
@@ -112,6 +116,7 @@ void test_alg_no_inverse(F f, typename F::Partial identity, uint64_t iterations,
         bclassic_agg.insert(i);
         bknuckle_agg.insert(i);
         bfinger_agg.insert(i);
+        amta_agg.insert(i);
 
         typename F::Out res = recalc_agg.query();
         real_assert(res == daba_agg.query(), name + ": recalc != daba");
@@ -129,6 +134,7 @@ void test_alg_no_inverse(F f, typename F::Partial identity, uint64_t iterations,
         real_assert(res == bclassic_agg.query(), name + ": recalc != bclassic");
         real_assert(res == bknuckle_agg.query(), name + ": recalc != bknuckle");
         real_assert(res == bfinger_agg.query(), name + ": recalc != bfinger");
+        real_assert(res == amta_agg.query(), name + ": recalc != amta");
     }
     std::cout << name << " passed" << std::endl;
 }
@@ -151,6 +157,7 @@ void test_alg_with_inverse(F f, typename F::Partial identity, uint64_t iteration
     auto bclassic_agg = btree::make_aggregate<timestamp, 2, btree::classic>(f, identity);
     auto bknuckle_agg = btree::make_aggregate<timestamp, 2, btree::knuckle>(f, identity);
     auto bfinger_agg = btree::make_aggregate<timestamp, 2, btree::finger>(f, identity);
+    auto amta_agg = amta::make_aggregate<timestamp>(f, identity);
 
     for (uint64_t i = 0; i < iterations; ++i) {
         size_t sz = recalc_agg.size();
@@ -168,6 +175,7 @@ void test_alg_with_inverse(F f, typename F::Partial identity, uint64_t iteration
         real_assert(sz == bclassic_agg.size(), name + ": recalc size != bclassic");
         real_assert(sz == bknuckle_agg.size(), name + ": recalc size != bknuckle");
         real_assert(sz == bfinger_agg.size(), name + ": recalc size != bfinger");
+        real_assert(sz == amta_agg.size(), name + ": recalc size != amta");
 
         if (recalc_agg.size() == window_size) {
             daba_agg.evict();
@@ -186,6 +194,7 @@ void test_alg_with_inverse(F f, typename F::Partial identity, uint64_t iteration
             bclassic_agg.evict();
             bknuckle_agg.evict();
             bfinger_agg.evict();
+            amta_agg.evict();
         }
 
         recalc_agg.insert(i);
@@ -204,6 +213,7 @@ void test_alg_with_inverse(F f, typename F::Partial identity, uint64_t iteration
         bclassic_agg.insert(i);
         bknuckle_agg.insert(i);
         bfinger_agg.insert(i);
+        amta_agg.insert(i);
 
         typename F::Out res = recalc_agg.query();
         real_assert(res == daba_agg.query(), name + ": recalc != daba");
@@ -221,6 +231,7 @@ void test_alg_with_inverse(F f, typename F::Partial identity, uint64_t iteration
         real_assert(res == bclassic_agg.query(), name + ": recalc != bclassic");
         real_assert(res == bknuckle_agg.query(), name + ": recalc != bknuckle");
         real_assert(res == bfinger_agg.query(), name + ": recalc != bfinger");
+        real_assert(res == amta_agg.query(), name + ": recalc != amta");
     }
     std::cout << name << " passed" << std::endl;
 }
@@ -245,6 +256,7 @@ void test_alg_no_inverse_sawtooth(F f, typename F::Partial identity,
   auto bclassic_agg = btree::make_aggregate<timestamp, 2, btree::classic>(f, identity);
   auto bknuckle_agg = btree::make_aggregate<timestamp, 2, btree::knuckle>(f, identity);
   auto bfinger_agg = btree::make_aggregate<timestamp, 2, btree::finger>(f, identity);
+  auto amta_agg = amta::make_aggregate<timestamp>(f, identity);
 
   while (rep-- > 0) {
     for (uint64_t i=0;i<window_size;i++) {
@@ -263,6 +275,7 @@ void test_alg_no_inverse_sawtooth(F f, typename F::Partial identity,
       bclassic_agg.insert(i);
       bknuckle_agg.insert(i);
       bfinger_agg.insert(i);
+      amta_agg.insert(i);
 
       typename F::Out res = recalc_agg.query();
       real_assert(res == daba_agg.query(), name + ": recalc != daba");
@@ -279,6 +292,7 @@ void test_alg_no_inverse_sawtooth(F f, typename F::Partial identity,
       real_assert(res == bclassic_agg.query(), name + ": recalc != bclassic");
       real_assert(res == bknuckle_agg.query(), name + ": recalc != bknuckle");
       real_assert(res == bfinger_agg.query(), name + ": recalc != bfinger");
+      real_assert(res == amta_agg.query(), name + ": recalc != amta");
     }
     // drain
     while (recalc_agg.size() > 0) {
@@ -297,6 +311,7 @@ void test_alg_no_inverse_sawtooth(F f, typename F::Partial identity,
       bclassic_agg.evict();
       bknuckle_agg.evict();
       bfinger_agg.evict();
+      amta_agg.evict();
 
       typename F::Out res = recalc_agg.query();
       real_assert(res == daba_agg.query(), name + ": recalc != daba");
@@ -313,6 +328,7 @@ void test_alg_no_inverse_sawtooth(F f, typename F::Partial identity,
       real_assert(res == bclassic_agg.query(), name + ": recalc != bclassic");
       real_assert(res == bknuckle_agg.query(), name + ": recalc != bknuckle");
       real_assert(res == bfinger_agg.query(), name + ": recalc != bfinger");
+      real_assert(res == amta_agg.query(), name + ": recalc != amta");
     }
     // std::cout << "round over" << std::endl;
   }
@@ -340,6 +356,7 @@ void test_alg_no_inverse_thirds(F f, typename F::Partial identity,
   auto bclassic_agg = btree::make_aggregate<timestamp, 2, btree::classic>(f, identity);
   auto bknuckle_agg = btree::make_aggregate<timestamp, 2, btree::knuckle>(f, identity);
   auto bfinger_agg = btree::make_aggregate<timestamp, 2, btree::finger>(f, identity);
+  auto amta_agg = amta::make_aggregate<timestamp>(f, identity);
 
   uint64_t third = window_size / 3;
   // seesawing between 1/3 and n
@@ -362,6 +379,7 @@ void test_alg_no_inverse_thirds(F f, typename F::Partial identity,
       bclassic_agg.insert(epoch_no);
       bknuckle_agg.insert(epoch_no);
       bfinger_agg.insert(epoch_no);
+      amta_agg.insert(epoch_no);
 
       typename F::Out res = recalc_agg.query();
       real_assert(res == daba_agg.query(), name + ": recalc != daba");
@@ -378,6 +396,7 @@ void test_alg_no_inverse_thirds(F f, typename F::Partial identity,
       real_assert(res == bclassic_agg.query(), name + ": recalc != bclassic");
       real_assert(res == bknuckle_agg.query(), name + ": recalc != bknuckle");
       real_assert(res == bfinger_agg.query(), name + ": recalc != bfinger");
+      real_assert(res == amta_agg.query(), name + ": recalc != amta");
     }
     // drain down to 1/3
     while (recalc_agg.size() > third) {
@@ -396,6 +415,7 @@ void test_alg_no_inverse_thirds(F f, typename F::Partial identity,
       bclassic_agg.evict();
       bknuckle_agg.evict();
       bfinger_agg.evict();
+      amta_agg.evict();
 
       typename F::Out res = recalc_agg.query();
       real_assert(res == daba_agg.query(), name + ": recalc != daba");
@@ -412,6 +432,7 @@ void test_alg_no_inverse_thirds(F f, typename F::Partial identity,
       real_assert(res == bclassic_agg.query(), name + ": recalc != bclassic");
       real_assert(res == bknuckle_agg.query(), name + ": recalc != bknuckle");
       real_assert(res == bfinger_agg.query(), name + ": recalc != bfinger");
+      real_assert(res == amta_agg.query(), name + ": recalc != amta");
     }
     // std::cout << "round over" << std::endl;
   }


### PR DESCRIPTION
This PR implements the Amortized MTA with O(1) amortized insert & evict, and worst-case O(1) query. It also supports `bulkEvict` in worst-case O(log n) time. It includes some basic testing (amta_test.cc), as well as more comprehensive testing as part of test.cc. 