### PR TITLE
Bulk experiments are runnable

### DIFF
--- a/cpp/src/BulkAdapter.hpp
+++ b/cpp/src/BulkAdapter.hpp
@@ -4,6 +4,7 @@
 
 template <class Base, typename timeT, typename inT>
 class BulkAdapter : public Base {
+public:
   using Base::Base;
 
   void bulkInsert(std::vector<std::pair<timeT, inT>> entries) {

--- a/cpp/src/SubtractOnEvict.hpp
+++ b/cpp/src/SubtractOnEvict.hpp
@@ -6,6 +6,12 @@
 #include<iterator>
 #include<cassert>
 
+#ifdef DEBUG
+#define _IFDEBUG(x) x
+#else
+#define _IFDEBUG(x)
+#endif
+
 namespace soe {
   using namespace std;
 

--- a/cpp/src/TimestampedDABALite.hpp
+++ b/cpp/src/TimestampedDABALite.hpp
@@ -3,6 +3,7 @@
 
 #include<deque>
 #include"ChunkedArrayQueue.hpp"
+#include "RingBufferQueue.hpp"
 #include<iostream>
 #include<iterator>
 #include<cassert>

--- a/cpp/src/TimestampedDABALite.hpp
+++ b/cpp/src/TimestampedDABALite.hpp
@@ -13,6 +13,8 @@
 #define _IFDEBUG(x)
 #endif
 
+#include "BulkAdapter.hpp"
+
 namespace timestamped_dabalite {
   template<typename valT, typename timeT>
   class __AggT {
@@ -247,6 +249,25 @@ namespace timestamped_dabalite {
       return make_aggregate<timeT, BinaryFunction>(f, elem);
     }
   };
+   
+  template <typename timeT, class BinaryFunction, class T>
+  auto make_bulk_aggregate(BinaryFunction f, T elem) {
+    return BulkAdapter<
+        Aggregate<BinaryFunction, timeT>,
+        timeT,
+        typename BinaryFunction::In
+    >(f, elem);
+  }
+
+  template <typename BinaryFunction, typename timeT>
+  struct MakeBulkAggregate {
+    template <typename T>
+    auto operator()(T elem) {
+      BinaryFunction f;
+      return make_bulk_aggregate<timeT, BinaryFunction>(f, elem);
+    }
+  };
+ 
 }
 
 namespace timestamped_rb_dabalite {
@@ -278,6 +299,7 @@ namespace timestamped_rb_dabalite {
         return make_aggregate<MAX_CAPACITY, timeT, BinaryFunction>(f, elem);
     }
   };      
+
 }
 
 #endif

--- a/cpp/src/TimestampedTwoStacksLite.hpp
+++ b/cpp/src/TimestampedTwoStacksLite.hpp
@@ -6,6 +6,8 @@
 #include<iterator>
 #include<cassert>
 
+#include "BulkAdapter.hpp"
+
 namespace timestamped_twostacks_lite {
   using namespace std;
 
@@ -104,6 +106,25 @@ namespace timestamped_twostacks_lite {
       return make_aggregate<timeT, BinaryFunction>(f, elem);
     }
   };
+
+  template <typename timeT, class BinaryFunction, class T>
+  auto make_bulk_aggregate(BinaryFunction f, T elem) {
+    return BulkAdapter<
+        Aggregate<BinaryFunction, timeT>,
+        timeT,
+        typename BinaryFunction::In
+    >(f, elem);
+  }
+
+  template <typename BinaryFunction, typename timeT>
+  struct MakeBulkAggregate {
+    template <typename T>
+    auto operator()(T elem) {
+      BinaryFunction f;
+      return make_bulk_aggregate<timeT, BinaryFunction>(f, elem);
+    }
+  };
+
 }
 
 #endif

--- a/cpp/src/benchmark_core.h
+++ b/cpp/src/benchmark_core.h
@@ -11,35 +11,12 @@
 #include <chrono>
 #include <iterator>
 
-#include "DABA.hpp"
-#include "DABALite.hpp"
-#include "TwoStacks.hpp"
-#include "TwoStacksLite.hpp"
-#include "ImplicitTwoStacksLite.hpp"
-#include "FlatFIT.hpp"
-#include "FlatFIT.hpp"
-#include "DynamicFlatFIT.hpp"
-#include "ImplicitQueueABA.hpp"
-#include "SubtractOnEvict.hpp"
-#include "ReCalc.hpp"
-#include "Reactive.hpp"
 #include "AggregationFunctions.hpp"
-#include "OkasakisQueue.hpp"
-#include "Reactive.hpp"
+
+#include "SubtractOnEvict.hpp"
 #include "FiBA.hpp"
 
-#include "TimestampedTwoStacks.hpp"
-#include "TimestampedTwoStacksLite.hpp"
-#include "TimestampedImplicitTwoStacksLite.hpp"
-#include "TimestampedDynamicFlatFIT.hpp"
-#include "TimestampedDABA.hpp"
-#include "TimestampedDABALite.hpp"
-
-#include "DataGenerators.h"
-
 #include "utils.h"
-
-//typedef long long int timestamp;
 
 template <typename T>
 struct IdentityLifter {

--- a/cpp/src/benchmark_core.h
+++ b/cpp/src/benchmark_core.h
@@ -1193,6 +1193,57 @@ bool query_call_bulk_evict_insert_benchmark(std::string aggregator, std::string 
 template <
     template <
         typename, 
+        typename time
+    > class MakeAggregate, 
+    typename time
+>
+bool query_call_bulk_evict_insert_benchmark(std::string aggregator, std::string aggregator_req, std::string function_req, Experiment exp) {
+    if (aggregator_req == aggregator && function_req == "sum") {
+        bulk_evict_insert_benchmark(MakeAggregate<Sum<int>, time>()(0), exp);
+        return true;
+    }
+    else if (aggregator_req == aggregator && function_req == "max") {
+        bulk_evict_insert_benchmark(MakeAggregate<Max<int>, time>()(0), exp);
+        return true;
+    }
+    else if (aggregator_req == aggregator && function_req == "mean") {
+        bulk_evict_insert_benchmark(MakeAggregate<Mean<int>, time>()(Mean<int>::identity), exp);
+        return true;
+    }
+    else if (aggregator_req == aggregator && function_req == "stddev") {
+        bulk_evict_insert_benchmark(MakeAggregate<SampleStdDev<int>, time>()(SampleStdDev<int>::identity), exp);
+        return true;
+    }
+    else if (aggregator_req == aggregator && function_req == "argmax") {
+        bulk_evict_insert_benchmark(MakeAggregate<ArgMax<int, int, IdentityLifter<int>>, time>()(ArgMax<int, int, IdentityLifter<int>>::identity), exp);
+        return true;
+    }
+    else if (aggregator_req == aggregator && function_req == "bloom") {
+        bulk_evict_insert_benchmark(MakeAggregate<BloomFilter<int>, time>()(BloomFilter<int>::identity), exp);
+        return true;
+    }
+    else if (aggregator_req == aggregator && function_req == "collect") {
+        bulk_evict_insert_benchmark(MakeAggregate<Collect<int>, time>()(Collect<int>::identity), exp);
+        return true;
+    }
+    else if (aggregator_req == aggregator && function_req == "mincount") {
+        bulk_evict_insert_benchmark(MakeAggregate<MinCount<int>, time>()(MinCount<int>::identity), exp);
+        return true;
+    }
+    else if (aggregator_req == aggregator && function_req == "geomean") {
+        bulk_evict_insert_benchmark(MakeAggregate<GeometricMean<int>, time>()(GeometricMean<int>::identity), exp);
+        return true;
+    }
+    else if (aggregator_req == aggregator && function_req == "busyloop") {
+        bulk_evict_insert_benchmark(MakeAggregate<BusyLoop<int>, time>()(0), exp);
+        return true;
+    }
+    return false;
+}
+
+template <
+    template <
+        typename, 
         bool caching
     > class MakeAggregate, 
     bool caching

--- a/cpp/src/benchmark_core.h
+++ b/cpp/src/benchmark_core.h
@@ -1087,6 +1087,57 @@ bool query_call_bulk_evict_benchmark(std::string aggregator, std::string aggrega
 template <
     template <
         typename, 
+        typename time
+    > class MakeAggregate, 
+    typename time
+>
+bool query_call_bulk_evict_benchmark(std::string aggregator, std::string aggregator_req, std::string function_req, Experiment exp) {
+    if (aggregator_req == aggregator && function_req == "sum") {
+        bulk_evict_benchmark(MakeAggregate<Sum<int>, time>()(0), exp);
+        return true;
+    }
+    else if (aggregator_req == aggregator && function_req == "max") {
+        bulk_evict_benchmark(MakeAggregate<Max<int>, time>()(0), exp);
+        return true;
+    }
+    else if (aggregator_req == aggregator && function_req == "mean") {
+        bulk_evict_benchmark(MakeAggregate<Mean<int>, time>()(Mean<int>::identity), exp);
+        return true;
+    }
+    else if (aggregator_req == aggregator && function_req == "stddev") {
+        bulk_evict_benchmark(MakeAggregate<SampleStdDev<int>, time>()(SampleStdDev<int>::identity), exp);
+        return true;
+    }
+    else if (aggregator_req == aggregator && function_req == "argmax") {
+        bulk_evict_benchmark(MakeAggregate<ArgMax<int, int, IdentityLifter<int>>, time>()(ArgMax<int, int, IdentityLifter<int>>::identity), exp);
+        return true;
+    }
+    else if (aggregator_req == aggregator && function_req == "bloom") {
+        bulk_evict_benchmark(MakeAggregate<BloomFilter<int>, time>()(BloomFilter<int>::identity), exp);
+        return true;
+    }
+    else if (aggregator_req == aggregator && function_req == "collect") {
+        bulk_evict_benchmark(MakeAggregate<Collect<int>, time>()(Collect<int>::identity), exp);
+        return true;
+    }
+    else if (aggregator_req == aggregator && function_req == "mincount") {
+        bulk_evict_benchmark(MakeAggregate<MinCount<int>, time>()(MinCount<int>::identity), exp);
+        return true;
+    }
+    else if (aggregator_req == aggregator && function_req == "geomean") {
+        bulk_evict_benchmark(MakeAggregate<GeometricMean<int>, time>()(GeometricMean<int>::identity), exp);
+        return true;
+    }
+    else if (aggregator_req == aggregator && function_req == "busyloop") {
+        bulk_evict_benchmark(MakeAggregate<BusyLoop<int>, time>()(0), exp);
+        return true;
+    }
+    return false;
+}
+
+template <
+    template <
+        typename, 
         typename time, 
         int minDegree, 
         btree::Kind kind

--- a/cpp/src/benchmark_driver.cc
+++ b/cpp/src/benchmark_driver.cc
@@ -1,5 +1,20 @@
 #include "benchmark_core.h"
 
+#include "DABA.hpp"
+#include "DABALite.hpp"
+#include "TwoStacks.hpp"
+#include "TwoStacksLite.hpp"
+#include "ImplicitTwoStacksLite.hpp"
+#include "FlatFIT.hpp"
+#include "DynamicFlatFIT.hpp"
+#include "ImplicitQueueABA.hpp"
+#include "SubtractOnEvict.hpp"
+#include "ReCalc.hpp"
+#include "Reactive.hpp"
+#include "OkasakisQueue.hpp"
+#include "Reactive.hpp"
+#include "FiBA.hpp"
+
 typedef uint64_t timestamp;
 
 template <template <typename, typename time> class MakeAggregate, typename time>

--- a/cpp/src/bulk_evict_benchmark_driver.cc
+++ b/cpp/src/bulk_evict_benchmark_driver.cc
@@ -1,6 +1,10 @@
 #include "benchmark_core.h"
-#include "AMTA.hpp"
 #include "utils.h"
+
+#include "AMTA.hpp"
+#include "FiBA.hpp"
+#include "TimestampedTwoStacksLite.hpp"
+#include "TimestampedDABALite.hpp"
 
 typedef uint64_t timestamp;
 

--- a/cpp/src/bulk_evict_benchmark_driver.cc
+++ b/cpp/src/bulk_evict_benchmark_driver.cc
@@ -1,4 +1,5 @@
 #include "benchmark_core.h"
+#include "AMTA.hpp"
 #include "utils.h"
 
 typedef uint64_t timestamp;
@@ -40,13 +41,10 @@ int main(int argc, char** argv) {
           query_call_bulk_evict_benchmark<btree::MakeAggregate, timestamp, 4, btree::finger>("bfinger4", aggregator, function, exp) ||
           query_call_bulk_evict_benchmark<btree::MakeAggregate, timestamp, 8, btree::finger>("bfinger8", aggregator, function, exp) ||
 
-          query_call_bulk_evict_benchmark<btree::MakeAggregate, timestamp, 2, btree::classic>("bclassic2", aggregator, function, exp) ||
-          query_call_bulk_evict_benchmark<btree::MakeAggregate, timestamp, 4, btree::classic>("bclassic4", aggregator, function, exp) ||
-          query_call_bulk_evict_benchmark<btree::MakeAggregate, timestamp, 8, btree::classic>("bclassic8", aggregator, function, exp) ||
 
-          query_call_bulk_evict_benchmark<btree::MakeAggregate, timestamp, 2, btree::knuckle>("bknuckle2", aggregator, function, exp) ||
-          query_call_bulk_evict_benchmark<btree::MakeAggregate, timestamp, 4, btree::knuckle>("bknuckle4", aggregator, function, exp) ||
-          query_call_bulk_evict_benchmark<btree::MakeAggregate, timestamp, 8, btree::knuckle>("bknuckle8", aggregator, function, exp)
+          query_call_bulk_evict_benchmark<timestamped_twostacks_lite::MakeBulkAggregate, timestamp>("two_stacks_lite", aggregator, function, exp) ||
+          query_call_bulk_evict_benchmark<timestamped_dabalite::MakeBulkAggregate, timestamp>("daba_lite", aggregator, function, exp) ||
+          query_call_bulk_evict_benchmark<amta::MakeAggregate, timestamp>("amta", aggregator, function, exp)
        )) {
         std::cerr << "error: no matching kind of experiment: " << aggregator << ", " << function << std::endl;
         return 2;

--- a/cpp/src/bulk_evict_insert_benchmark_driver.cc
+++ b/cpp/src/bulk_evict_insert_benchmark_driver.cc
@@ -1,6 +1,10 @@
 #include "benchmark_core.h"
-#include "AMTA.hpp"
 #include "utils.h"
+
+#include "AMTA.hpp"
+#include "FiBA.hpp"
+#include "TimestampedTwoStacksLite.hpp"
+#include "TimestampedDABALite.hpp"
 
 typedef uint64_t timestamp;
 

--- a/cpp/src/bulk_evict_insert_benchmark_driver.cc
+++ b/cpp/src/bulk_evict_insert_benchmark_driver.cc
@@ -1,4 +1,5 @@
 #include "benchmark_core.h"
+#include "AMTA.hpp"
 #include "utils.h"
 
 typedef uint64_t timestamp;
@@ -40,13 +41,9 @@ int main(int argc, char** argv) {
           query_call_bulk_evict_insert_benchmark<btree::MakeAggregate, timestamp, 4, btree::finger>("bfinger4", aggregator, function, exp) ||
           query_call_bulk_evict_insert_benchmark<btree::MakeAggregate, timestamp, 8, btree::finger>("bfinger8", aggregator, function, exp) ||
 
-          query_call_bulk_evict_insert_benchmark<btree::MakeAggregate, timestamp, 2, btree::classic>("bclassic2", aggregator, function, exp) ||
-          query_call_bulk_evict_insert_benchmark<btree::MakeAggregate, timestamp, 4, btree::classic>("bclassic4", aggregator, function, exp) ||
-          query_call_bulk_evict_insert_benchmark<btree::MakeAggregate, timestamp, 8, btree::classic>("bclassic8", aggregator, function, exp) ||
-
-          query_call_bulk_evict_insert_benchmark<btree::MakeAggregate, timestamp, 2, btree::knuckle>("bknuckle2", aggregator, function, exp) ||
-          query_call_bulk_evict_insert_benchmark<btree::MakeAggregate, timestamp, 4, btree::knuckle>("bknuckle4", aggregator, function, exp) ||
-          query_call_bulk_evict_insert_benchmark<btree::MakeAggregate, timestamp, 8, btree::knuckle>("bknuckle8", aggregator, function, exp)
+          query_call_bulk_evict_insert_benchmark<timestamped_twostacks_lite::MakeBulkAggregate, timestamp>("two_stacks_lite", aggregator, function, exp) ||
+          query_call_bulk_evict_insert_benchmark<timestamped_dabalite::MakeBulkAggregate, timestamp>("daba_lite", aggregator, function, exp) ||
+          query_call_bulk_evict_insert_benchmark<amta::MakeAggregate, timestamp>("amta", aggregator, function, exp)
        )) {
         std::cerr << "error: no matching kind of experiment: " << aggregator << ", " << function << std::endl;
         return 2;

--- a/cpp/src/data_benchmark.cc
+++ b/cpp/src/data_benchmark.cc
@@ -1,8 +1,16 @@
 #include <malloc.h>
-#include "DataGenerators.h"
 #include "benchmark_core.h"
-#include "TimestampedFifo.hpp"
+
 #include "utils.h"
+
+#include "DataGenerators.h"
+#include "TimestampedTwoStacks.hpp"
+#include "TimestampedTwoStacksLite.hpp"
+#include "TimestampedImplicitTwoStacksLite.hpp"
+#include "TimestampedDynamicFlatFIT.hpp"
+#include "TimestampedDABA.hpp"
+#include "TimestampedDABALite.hpp"
+#include "TimestampedFifo.hpp"
 
 #include <vector>
 #include <sstream>

--- a/cpp/src/dynamic_benchmark_driver.cc
+++ b/cpp/src/dynamic_benchmark_driver.cc
@@ -1,5 +1,20 @@
 #include "benchmark_core.h"
 
+#include "DABA.hpp"
+#include "DABALite.hpp"
+#include "TwoStacks.hpp"
+#include "TwoStacksLite.hpp"
+#include "ImplicitTwoStacksLite.hpp"
+#include "FlatFIT.hpp"
+#include "DynamicFlatFIT.hpp"
+#include "ImplicitQueueABA.hpp"
+#include "SubtractOnEvict.hpp"
+#include "ReCalc.hpp"
+#include "Reactive.hpp"
+#include "OkasakisQueue.hpp"
+#include "Reactive.hpp"
+#include "FiBA.hpp"
+
 typedef uint64_t timestamp;
 
 int main(int argc, char** argv) {

--- a/cpp/src/ooo_benchmark_driver.cc
+++ b/cpp/src/ooo_benchmark_driver.cc
@@ -1,6 +1,8 @@
 #include "benchmark_core.h"
 #include "utils.h"
 
+#include "FiBA.hpp"
+
 typedef uint64_t timestamp;
 
 int main(int argc, char** argv) {

--- a/cpp/src/shared_benchmark_driver.cc
+++ b/cpp/src/shared_benchmark_driver.cc
@@ -1,5 +1,7 @@
 #include "benchmark_core.h"
 
+#include "FiBA.hpp"
+
 typedef uint64_t timestamp;
 
 int main(int argc, char** argv) {

--- a/experiments/run_bulk_evict.py
+++ b/experiments/run_bulk_evict.py
@@ -3,26 +3,21 @@
 import run_utility as u
 
 aggregators = [
-                "bclassic2",
-                "bclassic4",
-                "bclassic8",
                 "bfinger2",
                 "bfinger4",
                 "bfinger8",
-                #"bfinger16",
-                #"bfinger32",
+                "amta",
+                "two_stacks_lite",
+                "daba_lite",
               ]
 
-degrees = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 
-           1*u.KB, 2*u.KB, 4*u.KB, 8*u.KB, 16*u.KB, 32*u.KB, 64*u.KB, 128*u.KB, 256*u.KB, 512*u.KB,
-           1*u.MB, 2*u.MB, 4*u.MB]
+degrees = [0]
 
 base_window_sizes = [4*u.MB]
-                    #[1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 
-                    # 1*u.KB, 2*u.KB, 4*u.KB, 8*u.KB, 16*u.KB, 32*u.KB, 64*u.KB, 128*u.KB, 256*u.KB, 512*u.KB,
-                    # 1*u.MB, 2*u.MB, 4*u.MB]
 
-base_iterations = 100 * u.MILLION
+base_iterations = 10 * u.MILLION
+
+bulk_sizes = [1, 256]
 
 functions = { 
              "sum": (base_iterations, base_window_sizes),
@@ -31,7 +26,7 @@ functions = {
             }
 
 def main():
-    u.run_ooo(aggregators, functions, degrees, 'bulk_evict')
+    u.run_bulk(aggregators, functions, degrees, bulk_sizes, 'bulk_evict', 1)
 
 if __name__ == "__main__":
     main()

--- a/experiments/run_bulk_evict.py
+++ b/experiments/run_bulk_evict.py
@@ -26,7 +26,7 @@ functions = {
             }
 
 def main():
-    u.run_bulk(aggregators, functions, degrees, bulk_sizes, 'bulk_evict', 1)
+    u.run_bulk(aggregators, functions, degrees, bulk_sizes, 'bulk_evict')
 
 if __name__ == "__main__":
     main()

--- a/experiments/run_bulk_evict_insert.py
+++ b/experiments/run_bulk_evict_insert.py
@@ -1,28 +1,25 @@
 #!/usr/bin/env python2.7
 
-import run_utilities as u
+import run_utility as u
 
 aggregators = [
-                "bclassic2",
-                "bclassic4",
-                "bclassic8",
                 "bfinger2",
                 "bfinger4",
                 "bfinger8",
-                #"bfinger16",
-                #"bfinger32",
+                "amta",
+                "two_stacks_lite",
+                "daba_lite",
               ]
 
-degrees = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 
-           1*u.KB, 2*u.KB, 4*u.KB, 8*u.KB, 16*u.KB, 32*u.KB, 64*u.KB, 128*u.KB, 256*u.KB, 512*u.KB,
-           1*u.MB, 2*u.MB, 4*u.MB]
+degrees = [0]
+
+# the current window sizes and iterations take an enormously long time
 
 base_window_sizes = [4*u.MB]
-                    #[1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 
-                    # 1*u.KB, 2*u.KB, 4*u.KB, 8*u.KB, 16*u.KB, 32*u.KB, 64*u.KB, 128*u.KB, 256*u.KB, 512*u.KB,
-                    # 1*u.MB, 2*u.MB, 4*u.MB]
 
-base_iterations = 100 * u.MILLION
+base_iterations = 1 * u.MILLION
+
+bulk_sizes = [1, 256]
 
 functions = { 
              "sum": (base_iterations, base_window_sizes),
@@ -31,7 +28,7 @@ functions = {
             }
 
 def main():
-    u.run_ooo(aggregators, functions, degrees, 'bulk_evict_insert')
+    u.run_bulk(aggregators, functions, degrees, bulk_sizes, 'bulk_evict_insert')
 
 if __name__ == "__main__":
     main()

--- a/experiments/run_bulk_evict_insert.py
+++ b/experiments/run_bulk_evict_insert.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2.7
 
-import utilities as u
+import run_utilities as u
 
 aggregators = [
                 "bclassic2",

--- a/experiments/run_utility.py
+++ b/experiments/run_utility.py
@@ -77,6 +77,37 @@ def run_ooo(aggregators, functions, degrees, name_base, sample_size=5):
 
         results_file.close()
 
+
+def run_bulk(aggregators, functions, degrees, bulks, name_base, sample_size=5):
+    for agg in aggregators:
+        with open('results/' + name_base + '_' + agg + '.csv', 'w') as results_file:
+            results = csv.writer(results_file)
+
+            for f, params in functions.iteritems():
+                print agg + '_' + f
+                base_iterations = params[0]
+                window_sizes = params[1]
+
+                for w in window_sizes:
+                    for d in degrees:
+                        if d > w:
+                            continue
+                        row = [f, w, d]
+                        print w, d, ':',
+
+                        iterations = base_iterations + w
+                        for b in bulks:
+                            for i in range(sample_size):
+                                runtime = exec_runtime(['../bin/' + name_base + '_benchmark_driver', agg, f, str(w), str(d), str(b), str(iterations)])
+                                print runtime,
+                                sys.stdout.flush()
+                                row.append(runtime)
+
+                        print
+                        results.writerow(row)
+                        results_file.flush()
+
+
 def run_fifo(aggregators, functions, name_base, sample_size=5):
     for agg in aggregators:
         results_file = open('results/' + name_base + '_' + agg + '.csv', 'w')


### PR DESCRIPTION
Two things to note:

1. The experiments will not complete because they encounter a runtime error with AMTA; the experiments do a check to make sure that the window size is what we think it is, and that check fails.
2. The bulk-evict-insert benchmarks take a surprising amount of time. They appear to be slower than the bulk-evict benchmarks. We'll need to investigate.