### PR TITLE
AMTA bug fixes: incorrect size, memory error during bulkEvict

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -1,4 +1,18 @@
-CXXFLAGS=-std=gnu++17 -DHAS_UNCAUGHT_EXCEPTIONS=1 -static -O3 -DNDEBUG ${EXTRAS}
+UNAME := $(shell uname)
+
+ifeq ($(UNAME), Darwin)
+	EXTRAS = 
+else
+	EXTRAS = -static
+endif
+
+DEBUG ?= 0
+ifeq ($(DEBUG), 1)
+	CXXFLAGS=-std=gnu++17 -DHAS_UNCAUGHT_EXCEPTIONS=1 -g -fsanitize=address -fno-omit-frame-pointer ${EXTRAS}
+else
+	CXXFLAGS=-std=gnu++17 -DHAS_UNCAUGHT_EXCEPTIONS=1 -O3 -DNDEBUG ${EXTRAS}
+endif
+
 SWAG_ALGOS=src/ChunkedArrayQueue.hpp \
 		   src/TwoStacks.hpp src/TwoStacksLite.hpp\
            src/ImplicitQueueABA.hpp src/DABA.hpp src/DABALite.hpp \

--- a/cpp/src/AMTA.hpp
+++ b/cpp/src/AMTA.hpp
@@ -197,7 +197,8 @@ public:
         }
       }
       if (!node->rightEmpty() && time < node->times[1]) {
-          _deleteNode(node->pop_front());
+          if (!node->leftPopped())
+            _deleteNode(node->pop_front());
           node = node->children[1];
           continue;
       }


### PR DESCRIPTION
This PR fixes the following bugs:
* `size()` was incorrect following an `insert(t, v)` call.
* Segmentation fault/double-free errors during `bulkEvict`

The latter bug happened because the left subtree of a node may have already been deleted while `bulkEvict` works to slice its right subtree. The previous code tried to delete the (removed) left subtree again, causing the error.

This PR also improves the `Makefile` to allow Valgrind-like debugging, as well as compiling without `-static` when run on a Mac OS machine. 