### PR TITLE
Perf Issue Fix: Run checkInvariant for bulkInsert only in debug mode

### DIFF
--- a/cpp/src/FiBA.hpp
+++ b/cpp/src/FiBA.hpp
@@ -1807,7 +1807,7 @@ public:
       }
     }
     if (false) cout << "_dump: " << *_root << endl;
-    checkInvariant(__FILE__, __LINE__);
+    assert(checkInvariant(__FILE__, __LINE__));
     if (false) cout << "---------------- done bulkInsert ------------------" << endl;
   }
 


### PR DESCRIPTION
Previously, the code ran the check invariant code after every `bulkInsert`, making it spend super-linear time in the size of the window every time a new bulk arrives. This fix makes the check invariant code run only in debug mode.