### PR TITLE
Add loop-based bulk for FiBA

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -8,6 +8,7 @@ endif
 
 DEBUG ?= 0
 ifeq ($(DEBUG), 1)
+	EXTRAS = 
 	CXXFLAGS=-std=gnu++17 -DHAS_UNCAUGHT_EXCEPTIONS=1 -g -fsanitize=address -fno-omit-frame-pointer ${EXTRAS}
 else
 	CXXFLAGS=-std=gnu++17 -DHAS_UNCAUGHT_EXCEPTIONS=1 -O3 -DNDEBUG ${EXTRAS}

--- a/cpp/src/BulkAdapter.hpp
+++ b/cpp/src/BulkAdapter.hpp
@@ -19,7 +19,7 @@ public:
   }
 
   void bulkEvict(timeT const& time) {
-      while (Base::oldest() <= time) {
+      while (Base::size() > 0 && Base::oldest() <= time) {
           Base::evict();
       }
   }

--- a/cpp/src/FiBA.hpp
+++ b/cpp/src/FiBA.hpp
@@ -1940,28 +1940,42 @@ public:
   }
 };
 
-template <typename timeT, int minArity, Kind kind, class BinaryFunction, class T, bool simulatedBulk=false>
+template <typename timeT, int minArity, Kind kind, class BinaryFunction, class T>
 Aggregate<timeT, minArity, kind, BinaryFunction>
 make_aggregate(BinaryFunction f, T elem) {
-  if (simulatedBulk)
-    return BulkAdapter<
-      Aggregate<timeT, minArity, kind, BinaryFunction>,
-      timeT, typename BinaryFunction::In
-      >(f);
-  else
     return Aggregate<timeT, minArity, kind, BinaryFunction>(f);
 }
 
-template <typename BinaryFunction, typename timeT, int minArity, Kind kind, bool simulatedBulk=false>
+template <typename BinaryFunction, typename timeT, int minArity, Kind kind>
 struct MakeAggregate {
   template <typename T>
-  Aggregate<timeT, minArity, kind, BinaryFunction> operator()(T elem) {
+Aggregate<timeT, minArity, kind, BinaryFunction> operator()(T elem) {
     BinaryFunction f;
     return make_aggregate<
       timeT, minArity, kind,
       BinaryFunction,
-      typename BinaryFunction::Partial,
-      simulatedBulk
+      typename BinaryFunction::Partial
+      >(f, elem);
+  }
+};
+
+template <typename timeT, int minArity, Kind kind, class BinaryFunction, class T>
+auto make_bulk_aggregate(BinaryFunction f, T elem) {
+  return BulkAdapter<
+    Aggregate<timeT, minArity, kind, BinaryFunction>,
+    timeT, typename BinaryFunction::In
+    >(f);
+}
+
+template <typename BinaryFunction, typename timeT, int minArity, Kind kind>
+struct MakeBulkAggregate {
+  template <typename T>
+  auto operator()(T elem) {
+    BinaryFunction f;
+    return make_bulk_aggregate<
+      timeT, minArity, kind,
+      BinaryFunction,
+      typename BinaryFunction::Partial
       >(f, elem);
   }
 };

--- a/cpp/src/bulk_evict_benchmark_driver.cc
+++ b/cpp/src/bulk_evict_benchmark_driver.cc
@@ -50,11 +50,14 @@ int main(int argc, char** argv) {
           query_call_bulk_evict_benchmark<btree::MakeAggregate, timestamp, 4, btree::finger>("bfinger4", aggregator, function, exp) ||
           query_call_bulk_evict_benchmark<btree::MakeAggregate, timestamp, 8, btree::finger>("bfinger8", aggregator, function, exp) ||
 
+          query_call_bulk_evict_benchmark<btree::MakeBulkAggregate, timestamp, 2, btree::finger>("nbfinger2", aggregator, function, exp) ||
+          query_call_bulk_evict_benchmark<btree::MakeBulkAggregate, timestamp, 4, btree::finger>("nbfinger4", aggregator, function, exp) ||
+          query_call_bulk_evict_benchmark<btree::MakeBulkAggregate, timestamp, 8, btree::finger>("nbfinger8", aggregator, function, exp) ||
 
           query_call_bulk_evict_benchmark<timestamped_twostacks_lite::MakeBulkAggregate, timestamp>("two_stacks_lite", aggregator, function, exp) ||
           query_call_bulk_evict_benchmark<timestamped_dabalite::MakeBulkAggregate, timestamp>("daba_lite", aggregator, function, exp) ||
           query_call_bulk_evict_benchmark<amta::MakeAggregate, timestamp>("amta", aggregator, function, exp)
-       )) {
+          )) {
         std::cerr << "error: no matching kind of experiment: " << aggregator << ", " << function << std::endl;
         return 2;
     }

--- a/cpp/src/bulk_evict_insert_benchmark_driver.cc
+++ b/cpp/src/bulk_evict_insert_benchmark_driver.cc
@@ -49,6 +49,10 @@ int main(int argc, char** argv) {
     if (!(query_call_bulk_evict_insert_benchmark<btree::MakeAggregate, timestamp, 2, btree::finger>("bfinger2", aggregator, function, exp) ||
           query_call_bulk_evict_insert_benchmark<btree::MakeAggregate, timestamp, 4, btree::finger>("bfinger4", aggregator, function, exp) ||
           query_call_bulk_evict_insert_benchmark<btree::MakeAggregate, timestamp, 8, btree::finger>("bfinger8", aggregator, function, exp) ||
+          
+          query_call_bulk_evict_insert_benchmark<btree::MakeBulkAggregate, timestamp, 2, btree::finger>("nbfinger2", aggregator, function, exp) ||
+          query_call_bulk_evict_insert_benchmark<btree::MakeBulkAggregate, timestamp, 4, btree::finger>("nbfinger4", aggregator, function, exp) ||
+          query_call_bulk_evict_insert_benchmark<btree::MakeBulkAggregate, timestamp, 8, btree::finger>("nbfinger8", aggregator, function, exp) ||
 
           query_call_bulk_evict_insert_benchmark<timestamped_twostacks_lite::MakeBulkAggregate, timestamp>("two_stacks_lite", aggregator, function, exp) ||
           query_call_bulk_evict_insert_benchmark<timestamped_dabalite::MakeBulkAggregate, timestamp>("daba_lite", aggregator, function, exp) ||

--- a/cpp/src/bulk_test.cc
+++ b/cpp/src/bulk_test.cc
@@ -350,7 +350,7 @@ void bulk_insert_from_random_trees() {
 
 template <int minArity, class F>
 void bulk_insert_from_adapter(F f) {
-  auto bfinger_wrapped = btree::make_aggregate<timestamp, minArity, btree::finger, F, typename F::Partial, true>(f, f.identity);
+  auto bfinger_wrapped = btree::make_bulk_aggregate<timestamp, minArity, btree::finger, F, typename F::Partial>(f, f.identity);
 
   vector<pair<timestamp, int>> bulkOne{
       make_pair(5, 105),           make_pair(507, 100 + 507),
@@ -369,7 +369,7 @@ void bulk_insert_from_adapter(F f) {
 
 template <int minArity, class F>
 void bulk_evict_from_adapter(F f) {
-  auto bfinger_wrapped = btree::make_aggregate<timestamp, minArity, btree::finger, F, typename F::Partial, true>(f, f.identity);
+  auto bfinger_wrapped = btree::make_bulk_aggregate<timestamp, minArity, btree::finger, F, typename F::Partial>(f, f.identity);
   vector<pair<timestamp, int>> bulkOne{
       make_pair(5, 105),           make_pair(507, 100 + 507),
       make_pair(509, 100 + 509),   make_pair(511, 100 + 511),

--- a/experiments/run_bulk_evict_insert_latency.py
+++ b/experiments/run_bulk_evict_insert_latency.py
@@ -6,6 +6,9 @@ aggregators = [
                 "bfinger2",
                 "bfinger4",
                 "bfinger8",
+                "nbfinger2",
+                "nbfinger4",
+                "nbfinger8",
                 "amta",
                 "two_stacks_lite",
                 "daba_lite",
@@ -15,7 +18,7 @@ degrees = [0, 256, 1024]
 
 base_window_sizes = [4*u.MB]
 
-base_iterations = 1 * u.MILLION
+base_iterations = 5 * u.MILLION
 
 bulk_sizes = [1, 256, 1024, 16384]
 

--- a/experiments/run_bulk_evict_latency.py
+++ b/experiments/run_bulk_evict_latency.py
@@ -6,6 +6,9 @@ aggregators = [
                 "bfinger2",
                 "bfinger4",
                 "bfinger8",
+                "nbfinger2",
+                "nbfinger4",
+                "nbfinger8",
                 "amta",
                 "two_stacks_lite",
                 "daba_lite",
@@ -15,7 +18,7 @@ degrees = [0]
 
 base_window_sizes = [4*u.MB]
 
-base_iterations = 1 * u.MILLION
+base_iterations = 5 * u.MILLION
 
 bulk_sizes = [1, 256, 1024, 16384]
 


### PR DESCRIPTION
This PR adds loop-based bulk experiments for FiBA. While FiBA natively supports bulk operations, loop-based operations (i.e., running insert and evict in a loop) are offered as an alternative--for benchmarking.  Specifically:
* A family of `nbfingerX` aggregators are now supported in the bulk experiments
* Scripts bulk latency experiments now contain the `nbfinger`s.
* A bug in the loop-based `bulkEvict` is fixed. (Previously, the code did not check whether the window is empty and could be asking for the oldest element on an empty window)